### PR TITLE
Make upstream dependency script not check out dependee repo

### DIFF
--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -43,8 +43,8 @@ iterations=0
 while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
 do
     echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
-    if git ls-remote \
-    --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}"
+    if git ls-remote --exit-code \
+    --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}"
     then
         dependency_branch_name=${branch_name_to_check}
         echo "Found matching dependency branch: ${dependency_branch_name}"

--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -4,44 +4,91 @@
 dependency_name=$1
 branch_name=$2
 workflow=$3
-
 root_dir=$(pwd)
 dependency_branch_name='main'
-branch_name_to_check=$(git rev-parse --abbrev-ref HEAD)
+
+# Try multiple methods to get the branch name
+if [ -n "$CHANGE_BRANCH" ]; then
+    # Jenkins pull request build
+    branch_name_to_check=$CHANGE_BRANCH
+elif [ -n "$BRANCH_NAME" ]; then
+    # Jenkins branch build
+    branch_name_to_check=$BRANCH_NAME
+elif [ -n "$GITHUB_HEAD_REF" ]; then
+    # GitHub Actions pull request
+    branch_name_to_check=$GITHUB_HEAD_REF
+elif [ -n "$GITHUB_REF_NAME" ]; then
+    # GitHub Actions branch build
+    branch_name_to_check=$GITHUB_REF_NAME
+else
+    # Local development - try to get branch name from git
+    branch_name_to_check=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --abbrev-ref HEAD)
+    
+    # If we're in detached HEAD state and can't determine branch, try to get it from the reflog
+    if [ "$branch_name_to_check" = "HEAD" ]; then
+        # Look for the last branch name in the reflog
+        branch_name_to_check=$(git reflog -1 | grep -o 'from \S*' | cut -d' ' -f2 | sed 's/^origin\///')
+        
+        # If still nothing, fall back to main
+        if [ -z "$branch_name_to_check" ]; then
+            echo "Could not determine branch name, defaulting to main"
+            branch_name_to_check="main"
+        fi
+    fi
+fi
+
+echo "Determined branch name: ${branch_name_to_check}"
 iterations=0
 
 while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
 do
-  echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
-  if git ls-remote --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}" == "0"
-  then
-    dependency_branch_name=${branch_name_to_check}
-    echo "Found matching branch: ${dependency_branch_name}"
-  else
-    echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
-    # Get the commit hash of where this branch diverged from main
-    merge_base=$(git merge-base "${branch_name_to_check}" "main")
-    # Find the next parent branch by getting the symbolic name of the merge base
-    branch_name_to_check=$(git name-rev --exclude "tags/*" --exclude "${branch_name_to_check}" --refs="refs/heads/*" --name-only "${merge_base}" | sed 's/\^[0-9]*$//')
-    
-    if [ -z "$branch_name_to_check" ] || [ "$branch_name_to_check" = "undefined" ]; then
-      echo "Could not find parent branch. Will use released version of ${dependency_name}."
-      branch_name_to_check="main"
+    echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
+    if git ls-remote --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}" == "0"
+    then
+        dependency_branch_name=${branch_name_to_check}
+        echo "Found matching branch: ${dependency_branch_name}"
+    else
+        echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
+        
+        # Try to find parent branch using git-merge-base and name-rev
+        merge_base=$(git merge-base "origin/main" HEAD 2>/dev/null)
+        if [ $? -eq 0 ] && [ -n "$merge_base" ]; then
+            branch_name_to_check=$(git name-rev --exclude "tags/*" --refs="refs/remotes/origin/*" --name-only "$merge_base" | sed 's/^origin\///' | sed 's/\^[0-9]*$//')
+        else
+            # If merge-base fails, try to get parent from GitHub API if we have a PR number
+            pr_number=$(echo "$branch_name_to_check" | grep -o 'PR-[0-9]*' | cut -d'-' -f2)
+            if [ -n "$pr_number" ] && [ -n "$GITHUB_TOKEN" ]; then
+                base_branch=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+                    "https://api.github.com/repos/ihmeuw/$dependency_name/pulls/$pr_number" | \
+                    grep '"base": {' -A 3 | grep '"ref":' | cut -d'"' -f4)
+                if [ -n "$base_branch" ]; then
+                    branch_name_to_check=$base_branch
+                else
+                    branch_name_to_check="main"
+                fi
+            else
+                branch_name_to_check="main"
+            fi
+        fi
+        
+        if [ -z "$branch_name_to_check" ] || [ "$branch_name_to_check" = "undefined" ]; then
+            echo "Could not find parent branch. Will use released version of ${dependency_name}."
+            branch_name_to_check="main"
+        fi
+        echo "Next branch to check: ${branch_name_to_check}"
+        iterations=$((iterations+1))
     fi
-    echo "Next branch to check: ${branch_name_to_check}"
-    iterations=$((iterations+1))
-  fi
 done
 
 if [ "$workflow" == "github" ]; then
-  echo "${dependency_name}_branch_name=${dependency_branch_name}" >> "$GITHUB_ENV"
+    echo "${dependency_name}_branch_name=${dependency_branch_name}" >> "$GITHUB_ENV"
 fi
 
 if [ "$dependency_branch_name" != "main" ]; then
-  echo "Cloning ${dependency_name} branch: ${dependency_branch_name}"
-  cd ..
-  git clone --branch="${dependency_branch_name}" https://github.com/ihmeuw/"${dependency_name}".git
-  cd "${dependency_name}" || exit
-  pip install .
-  cd "$root_dir" || exit
+    echo "Cloning ${dependency_name} branch: ${dependency_branch_name}"
+    cd ..
+    git clone --branch="${dependency_branch_name}" https://github.com/ihmeuw/"${dependency_name}".git
+    cd "${dependency_name}" || exit
+    pip install .
+    cd "$root_dir" || exit
 fi

--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -37,7 +37,7 @@ else
     fi
 fi
 
-echo "Determined branch name: ${branch_name_to_check}"
+echo "Determined dependee branch name: ${branch_name_to_check}"
 iterations=0
 
 while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
@@ -46,7 +46,7 @@ do
     if git ls-remote --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}"
     then
         dependency_branch_name=${branch_name_to_check}
-        echo "Found matching branch: ${dependency_branch_name}"
+        echo "Found matching dependency branch: ${dependency_branch_name}"
     else
         echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
         
@@ -78,63 +78,7 @@ do
             echo "Could not find parent branch. Will use released version of ${dependency_name}."
             branch_name_to_check="main"
         fi
-        echo "Next branch to check: ${branch_name_to_check}"
-        iterations=$((iterations+1))
-    fi
-done
-
-if [ "$workflow" == "github" ]; then
-    echo "${dependency_name}_branch_name=${dependency_branch_name}" >> "$GITHUB_ENV"
-fi
-
-if [ "$dependency_branch_name" != "main" ]; then
-    echo "Cloning ${dependency_name} branch: ${dependency_branch_name}"
-    cd ..
-    git clone --branch="${dependency_branch_name}" https://github.com/ihmeuw/"${dependency_name}".git
-    cd "${dependency_name}" || exit
-    pip install .
-    cd "$root_dir" || exit
-fi
-
-echo "Determined branch name: ${branch_name_to_check}"
-iterations=0
-
-while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
-do
-    echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
-    if git ls-remote --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}" == "0"
-    then
-        dependency_branch_name=${branch_name_to_check}
-        echo "Found matching branch: ${dependency_branch_name}"
-    else
-        echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
-        
-        # Try to find parent branch using git-merge-base and name-rev
-        merge_base=$(git merge-base "origin/main" HEAD 2>/dev/null)
-        if [ $? -eq 0 ] && [ -n "$merge_base" ]; then
-            branch_name_to_check=$(git name-rev --exclude "tags/*" --refs="refs/remotes/origin/*" --name-only "$merge_base" | sed 's/^origin\///' | sed 's/\^[0-9]*$//')
-        else
-            # If merge-base fails, try to get parent from GitHub API if we have a PR number
-            pr_number=$(echo "$branch_name_to_check" | grep -o 'PR-[0-9]*' | cut -d'-' -f2)
-            if [ -n "$pr_number" ] && [ -n "$GITHUB_TOKEN" ]; then
-                base_branch=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-                    "https://api.github.com/repos/ihmeuw/$dependency_name/pulls/$pr_number" | \
-                    grep '"base": {' -A 3 | grep '"ref":' | cut -d'"' -f4)
-                if [ -n "$base_branch" ]; then
-                    branch_name_to_check=$base_branch
-                else
-                    branch_name_to_check="main"
-                fi
-            else
-                branch_name_to_check="main"
-            fi
-        fi
-        
-        if [ -z "$branch_name_to_check" ] || [ "$branch_name_to_check" = "undefined" ]; then
-            echo "Could not find parent branch. Will use released version of ${dependency_name}."
-            branch_name_to_check="main"
-        fi
-        echo "Next branch to check: ${branch_name_to_check}"
+        echo "Next dependee branch to check: ${branch_name_to_check}"
         iterations=$((iterations+1))
     fi
 done

--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -43,6 +43,66 @@ iterations=0
 while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
 do
     echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
+    if git ls-remote --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}"
+    then
+        dependency_branch_name=${branch_name_to_check}
+        echo "Found matching branch: ${dependency_branch_name}"
+    else
+        echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
+        
+        # Try to find parent branch using git-merge-base and name-rev
+        merge_base=$(git merge-base origin/main HEAD 2>/dev/null)
+        if [ $? -eq 0 ] && [ -n "$merge_base" ]; then
+            # Get the parent branch name, removing remotes/origin/ prefix and any ^0 suffix
+            branch_name_to_check=$(git name-rev --exclude "tags/*" --refs="refs/remotes/origin/*" --name-only "$merge_base" | \
+                                 sed -E 's/^(remotes\/)?origin\///' | \
+                                 sed 's/\^[0-9]*$//')
+        else
+            # If merge-base fails, try to get parent from GitHub API if we have a PR number
+            pr_number=$(echo "$branch_name_to_check" | grep -o 'PR-[0-9]*' | cut -d'-' -f2)
+            if [ -n "$pr_number" ] && [ -n "$GITHUB_TOKEN" ]; then
+                base_branch=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+                    "https://api.github.com/repos/ihmeuw/$dependency_name/pulls/$pr_number" | \
+                    grep '"base": {' -A 3 | grep '"ref":' | cut -d'"' -f4)
+                if [ -n "$base_branch" ]; then
+                    branch_name_to_check=$base_branch
+                else
+                    branch_name_to_check="main"
+                fi
+            else
+                branch_name_to_check="main"
+            fi
+        fi
+        
+        if [ -z "$branch_name_to_check" ] || [ "$branch_name_to_check" = "undefined" ]; then
+            echo "Could not find parent branch. Will use released version of ${dependency_name}."
+            branch_name_to_check="main"
+        fi
+        echo "Next branch to check: ${branch_name_to_check}"
+        iterations=$((iterations+1))
+    fi
+done
+
+if [ "$workflow" == "github" ]; then
+    echo "${dependency_name}_branch_name=${dependency_branch_name}" >> "$GITHUB_ENV"
+fi
+
+if [ "$dependency_branch_name" != "main" ]; then
+    echo "Cloning ${dependency_name} branch: ${dependency_branch_name}"
+    cd ..
+    git clone --branch="${dependency_branch_name}" https://github.com/ihmeuw/"${dependency_name}".git
+    cd "${dependency_name}" || exit
+    pip install .
+    cd "$root_dir" || exit
+fi
+fi
+
+echo "Determined branch name: ${branch_name_to_check}"
+iterations=0
+
+while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
+do
+    echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
     if git ls-remote --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}" == "0"
     then
         dependency_branch_name=${branch_name_to_check}

--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -43,7 +43,8 @@ iterations=0
 while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
 do
     echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
-    if git ls-remote --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}"
+    if git ls-remote \
+    --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}"
     then
         dependency_branch_name=${branch_name_to_check}
         echo "Found matching dependency branch: ${dependency_branch_name}"

--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -43,7 +43,7 @@ iterations=0
 while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
 do
   echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
-  if 
+  if
     git ls-remote --exit-code \
     --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}"
   then

--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -9,32 +9,32 @@ dependency_branch_name='main'
 
 # Try multiple methods to get the branch name
 if [ -n "$CHANGE_BRANCH" ]; then
-    # Jenkins pull request build
-    branch_name_to_check=$CHANGE_BRANCH
+  # Jenkins pull request build
+  branch_name_to_check=$CHANGE_BRANCH
 elif [ -n "$BRANCH_NAME" ]; then
-    # Jenkins branch build
-    branch_name_to_check=$BRANCH_NAME
+  # Jenkins branch build
+  branch_name_to_check=$BRANCH_NAME
 elif [ -n "$GITHUB_HEAD_REF" ]; then
-    # GitHub Actions pull request
-    branch_name_to_check=$GITHUB_HEAD_REF
+  # GitHub Actions pull request
+  branch_name_to_check=$GITHUB_HEAD_REF
 elif [ -n "$GITHUB_REF_NAME" ]; then
-    # GitHub Actions branch build
-    branch_name_to_check=$GITHUB_REF_NAME
+  # GitHub Actions branch build
+  branch_name_to_check=$GITHUB_REF_NAME
 else
-    # Local development - try to get branch name from git
-    branch_name_to_check=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --abbrev-ref HEAD)
+  # Local development - try to get branch name from git
+  branch_name_to_check=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --abbrev-ref HEAD)
     
-    # If we're in detached HEAD state and can't determine branch, try to get it from the reflog
-    if [ "$branch_name_to_check" = "HEAD" ]; then
-        # Look for the last branch name in the reflog
-        branch_name_to_check=$(git reflog -1 | grep -o 'from \S*' | cut -d' ' -f2 | sed 's/^origin\///')
+  # If we're in detached HEAD state and can't determine branch, try to get it from the reflog
+  if [ "$branch_name_to_check" = "HEAD" ]; then
+    # Look for the last branch name in the reflog
+    branch_name_to_check=$(git reflog -1 | grep -o 'from \S*' | cut -d' ' -f2 | sed 's/^origin\///')
         
-        # If still nothing, fall back to main
-        if [ -z "$branch_name_to_check" ]; then
-            echo "Could not determine branch name, defaulting to main"
-            branch_name_to_check="main"
-        fi
-    fi
+    # If still nothing, fall back to main
+    if [ -z "$branch_name_to_check" ]; then
+      echo "Could not determine branch name, defaulting to main"
+      branch_name_to_check="main"
+      fi
+  fi
 fi
 
 echo "Determined dependee branch name: ${branch_name_to_check}"
@@ -42,57 +42,58 @@ iterations=0
 
 while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
 do
-    echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
-    if git ls-remote --exit-code \
+  echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
+  if 
+    git ls-remote --exit-code \
     --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}"
-    then
-        dependency_branch_name=${branch_name_to_check}
-        echo "Found matching dependency branch: ${dependency_branch_name}"
-    else
-        echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
+  then
+    dependency_branch_name=${branch_name_to_check}
+      echo "Found matching dependency branch: ${dependency_branch_name}"
+  else
+      echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
         
-        # Try to find parent branch using git-merge-base and name-rev
-        merge_base=$(git merge-base origin/main HEAD 2>/dev/null)
-        if [ $? -eq 0 ] && [ -n "$merge_base" ]; then
-            # Get the parent branch name, removing remotes/origin/ prefix and any ^0 suffix
-            branch_name_to_check=$(git name-rev --exclude "tags/*" --refs="refs/remotes/origin/*" --name-only "$merge_base" | \
-                                 sed -E 's/^(remotes\/)?origin\///' | \
-                                 sed 's/\^[0-9]*$//')
-        else
-            # If merge-base fails, try to get parent from GitHub API if we have a PR number
-            pr_number=$(echo "$branch_name_to_check" | grep -o 'PR-[0-9]*' | cut -d'-' -f2)
-            if [ -n "$pr_number" ] && [ -n "$GITHUB_TOKEN" ]; then
-                base_branch=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-                    "https://api.github.com/repos/ihmeuw/$dependency_name/pulls/$pr_number" | \
-                    grep '"base": {' -A 3 | grep '"ref":' | cut -d'"' -f4)
-                if [ -n "$base_branch" ]; then
-                    branch_name_to_check=$base_branch
-                else
-                    branch_name_to_check="main"
-                fi
+      # Try to find parent branch using git-merge-base and name-rev
+      merge_base=$(git merge-base origin/main HEAD 2>/dev/null)
+      if [ $? -eq 0 ] && [ -n "$merge_base" ]; then
+        # Get the parent branch name, removing remotes/origin/ prefix and any ^0 suffix
+        branch_name_to_check=$(git name-rev --exclude "tags/*" --refs="refs/remotes/origin/*" --name-only "$merge_base" | \
+                             sed -E 's/^(remotes\/)?origin\///' | \
+                             sed 's/\^[0-9]*$//')
+      else
+        # If merge-base fails, try to get parent from GitHub API if we have a PR number
+        pr_number=$(echo "$branch_name_to_check" | grep -o 'PR-[0-9]*' | cut -d'-' -f2)
+        if [ -n "$pr_number" ] && [ -n "$GITHUB_TOKEN" ]; then
+          base_branch=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/ihmeuw/$dependency_name/pulls/$pr_number" | \
+            grep '"base": {' -A 3 | grep '"ref":' | cut -d'"' -f4)
+            if [ -n "$base_branch" ]; then
+              branch_name_to_check=$base_branch
             else
-                branch_name_to_check="main"
+              branch_name_to_check="main"
             fi
+        else
+          branch_name_to_check="main"
         fi
+      fi
         
-        if [ -z "$branch_name_to_check" ] || [ "$branch_name_to_check" = "undefined" ]; then
-            echo "Could not find parent branch. Will use released version of ${dependency_name}."
-            branch_name_to_check="main"
-        fi
-        echo "Next dependee branch to check: ${branch_name_to_check}"
-        iterations=$((iterations+1))
-    fi
+      if [ -z "$branch_name_to_check" ] || [ "$branch_name_to_check" = "undefined" ]; then
+        echo "Could not find parent branch. Will use released version of ${dependency_name}."
+        branch_name_to_check="main"
+      fi
+      echo "Next dependee branch to check: ${branch_name_to_check}"
+      iterations=$((iterations+1))
+  fi
 done
 
 if [ "$workflow" == "github" ]; then
-    echo "${dependency_name}_branch_name=${dependency_branch_name}" >> "$GITHUB_ENV"
+  echo "${dependency_name}_branch_name=${dependency_branch_name}" >> "$GITHUB_ENV"
 fi
 
 if [ "$dependency_branch_name" != "main" ]; then
-    echo "Cloning ${dependency_name} branch: ${dependency_branch_name}"
-    cd ..
-    git clone --branch="${dependency_branch_name}" https://github.com/ihmeuw/"${dependency_name}".git
-    cd "${dependency_name}" || exit
-    pip install .
-    cd "$root_dir" || exit
+  echo "Cloning ${dependency_name} branch: ${dependency_branch_name}"
+  cd ..
+  git clone --branch="${dependency_branch_name}" https://github.com/ihmeuw/"${dependency_name}".git
+  cd "${dependency_name}" || exit
+  pip install .
+  cd "$root_dir" || exit
 fi

--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -95,7 +95,6 @@ if [ "$dependency_branch_name" != "main" ]; then
     pip install .
     cd "$root_dir" || exit
 fi
-fi
 
 echo "Determined branch name: ${branch_name_to_check}"
 iterations=0

--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -7,39 +7,31 @@ workflow=$3
 
 root_dir=$(pwd)
 dependency_branch_name='main'
-branch_name_to_check=${branch_name}
+branch_name_to_check=$(git rev-parse --abbrev-ref HEAD)
 iterations=0
 
 while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
 do
   echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
-  if
-    git ls-remote --exit-code \
-    --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}" == "0"
+  if git ls-remote --exit-code --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}" == "0"
   then
     dependency_branch_name=${branch_name_to_check}
     echo "Found matching branch: ${dependency_branch_name}"
   else
     echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
-    branch_name_to_check="$( \
-      git show-branch -a \
-      | grep '\*' \
-      | grep -v "${branch_name_to_check}" \
-      | head -n1 \
-      | sed 's/[^\[]*//' \
-      | awk 'match($0, /\[[a-zA-Z0-9\/.-]+\]/) { print substr( $0, RSTART+1, RLENGTH-2 )}' \
-      | sed 's/^origin\///' \
-    )"
-    if [ -z "$branch_name_to_check" ]; then
+    # Get the commit hash of where this branch diverged from main
+    merge_base=$(git merge-base "${branch_name_to_check}" main)
+    # Find the next parent branch by getting the symbolic name of the merge base
+    branch_name_to_check=$(git name-rev --exclude "tags/*" --exclude "${branch_name_to_check}" --refs="refs/heads/*" --name-only "${merge_base}" | sed 's/\^[0-9]*$//')
+    
+    if [ -z "$branch_name_to_check" ] || [ "$branch_name_to_check" = "undefined" ]; then
       echo "Could not find parent branch. Will use released version of ${dependency_name}."
       branch_name_to_check="main"
     fi
-    echo "Checking out branch: ${branch_name_to_check}"
-    git checkout "${branch_name_to_check}"
+    echo "Next branch to check: ${branch_name_to_check}"
     iterations=$((iterations+1))
   fi
 done
-git checkout "${branch_name}"
 
 if [ "$workflow" == "github" ]; then
   echo "${dependency_name}_branch_name=${dependency_branch_name}" >> "$GITHUB_ENV"

--- a/install_dependency_branch.sh
+++ b/install_dependency_branch.sh
@@ -20,7 +20,7 @@ do
   else
     echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
     # Get the commit hash of where this branch diverged from main
-    merge_base=$(git merge-base "${branch_name_to_check}" main)
+    merge_base=$(git merge-base "${branch_name_to_check}" "main")
     # Find the next parent branch by getting the symbolic name of the merge base
     branch_name_to_check=$(git name-rev --exclude "tags/*" --exclude "${branch_name_to_check}" --refs="refs/heads/*" --name-only "${merge_base}" | sed 's/\^[0-9]*$//')
     

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -160,16 +160,18 @@ def call(Map config = [:]){
                           def parallelTests = test_types.collectEntries {
                               ["${full_name(it)} Tests" : {
                                   stage("Run ${full_name(it)} Tests - Python ${pythonVersion}") {
-                                      sh "${ACTIVATE} && make ${it}"
-                                      publishHTML([
-                                        allowMissing: true,
-                                        alwaysLinkToLastBuild: false,
-                                        keepAll: true,
-                                        reportDir: "output/htmlcov_${it}",
-                                        reportFiles: "index.html",
-                                        reportName: "Coverage Report - ${full_name(it)} tests",
-                                        reportTitles: ''
-                                      ])
+                                      withEnv(['JAVA_OPTS=-Xmx4G', 'MAVEN_OPTS=-Xmx4G']) {
+                                          sh "${ACTIVATE} && make ${it}"
+                                          publishHTML([
+                                          allowMissing: true,
+                                          alwaysLinkToLastBuild: false,
+                                          keepAll: true,
+                                          reportDir: "output/htmlcov_${it}",
+                                          reportFiles: "index.html",
+                                          reportName: "Coverage Report - ${full_name(it)} tests",
+                                          reportTitles: ''
+                                        ])
+                                      }
                                   }
                               }]
                           }

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -160,18 +160,16 @@ def call(Map config = [:]){
                           def parallelTests = test_types.collectEntries {
                               ["${full_name(it)} Tests" : {
                                   stage("Run ${full_name(it)} Tests - Python ${pythonVersion}") {
-                                      withEnv(['JAVA_OPTS=-Xmx4G', 'MAVEN_OPTS=-Xmx4G']) {
-                                          sh "${ACTIVATE} && make ${it}"
-                                          publishHTML([
-                                          allowMissing: true,
-                                          alwaysLinkToLastBuild: false,
-                                          keepAll: true,
-                                          reportDir: "output/htmlcov_${it}",
-                                          reportFiles: "index.html",
-                                          reportName: "Coverage Report - ${full_name(it)} tests",
-                                          reportTitles: ''
-                                        ])
-                                      }
+                                      sh "${ACTIVATE} && make ${it}"
+                                      publishHTML([
+                                      allowMissing: true,
+                                      alwaysLinkToLastBuild: false,
+                                      keepAll: true,
+                                      reportDir: "output/htmlcov_${it}",
+                                      reportFiles: "index.html",
+                                      reportName: "Coverage Report - ${full_name(it)} tests",
+                                      reportTitles: ''
+                                    ])
                                   }
                               }]
                           }

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -162,14 +162,14 @@ def call(Map config = [:]){
                                   stage("Run ${full_name(it)} Tests - Python ${pythonVersion}") {
                                       sh "${ACTIVATE} && make ${it}"
                                       publishHTML([
-                                      allowMissing: true,
-                                      alwaysLinkToLastBuild: false,
-                                      keepAll: true,
-                                      reportDir: "output/htmlcov_${it}",
-                                      reportFiles: "index.html",
-                                      reportName: "Coverage Report - ${full_name(it)} tests",
-                                      reportTitles: ''
-                                    ])
+                                        allowMissing: true,
+                                        alwaysLinkToLastBuild: false,
+                                        keepAll: true,
+                                        reportDir: "output/htmlcov_${it}",
+                                        reportFiles: "index.html",
+                                        reportName: "Coverage Report - ${full_name(it)} tests",
+                                        reportTitles: ''
+                                      ])
                                   }
                               }]
                           }


### PR DESCRIPTION
## Make upstream dependency script not check out dependee repo
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, POC, refactor, 
                   revert, test, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5777

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I don't like that the upstream dependency script checks out the dependee repo to some branch and then reverts it.
Jenkins also needs a different environment variable for PR builds ($CHANGE_BRANCH)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Tried a couple builds with the new script, but not every use case (i.e. the github actions pieces)
Probably we need some better way to test this.
