### PR TITLE
Allow GBD_access to run

### DIFF
--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -63,9 +63,14 @@ install-upstream-deps: # Install upstream dependencies
 	@echo "----------------------------------------"
 	@sh $(UTILS_DIR)/resources/scripts/install_dependency_branch.sh $(DEPENDENCY_NAME) $(BRANCH_NAME) $(WORKFLOW)
 
-build-env: # Make a new conda environment
-	@[ "${CONDA_ENV_NAME}" ] && echo "" > /dev/null || ( echo "CONDA_ENV_NAME is not set"; exit 1 )
-	conda create ${CONDA_ENV_CREATION_FLAG} python=${PYTHON_VERSION} --yes
+create-env: ## Create a new conda environment
+	$(if $(ENV_NAME),,$(error ENV_NAME is not set. Usage: make create-env ENV_NAME=your_env_name))
+	conda create -n $(ENV_NAME) python=${PYTHON_VERSION} --yes
+
+build-env: ## Create environment and install packages
+	$(if $(ENV_NAME),,$(error ENV_NAME is not set. Usage: make build-env ENV_NAME=your_env_name))
+	make create-env ENV_NAME=$(ENV_NAME)
+	conda run -n $(ENV_NAME) make install
 
 format: setup.py pyproject.toml $(MAKE_SOURCES) # Run the code formatter and import sorter
 	isort $(LOCATIONS)

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -74,9 +74,26 @@ format: setup.py pyproject.toml $(MAKE_SOURCES) # Run the code formatter and imp
 build-doc: $(MAKE_SOURCES) # Build the Sphinx docs
 	$(MAKE) -C docs/ html
 
+deploy-doc: # Deploy the Sphinx docs
+	@[ "${DOCS_ROOT_PATH}" ] && echo "" > /dev/null || ( echo "DOCS_ROOT_PATH is not set"; exit 1 )
+	mkdir -m 0775 -p ${DOCS_ROOT_PATH}/${PACKAGE_NAME}/${PACKAGE_VERSION}
+	cp -R ./output/docs_build/* ${DOCS_ROOT_PATH}/${PACKAGE_NAME}/${PACKAGE_VERSION}
+	chmod -R 0775 ${DOCS_ROOT_PATH}/${PACKAGE_NAME}/${PACKAGE_VERSION}
+	cd ${DOCS_ROOT_PATH}/${PACKAGE_NAME} && ln -nsFfv ${PACKAGE_VERSION} current
+
 build-package: $(MAKE_SOURCES) # Build the package as a pip wheel
 	pip install build
 	python -m build
+
+deploy-package-artifactory: # Deploy the package to Artifactory
+	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_USR}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_USR is not set"; exit 1 )
+	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_PSW}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_PSW is not set"; exit 1 )
+	pip install twine
+	twine upload --repository-url ${IHME_PYPI} -u ${PYPI_ARTIFACTORY_CREDENTIALS_USR} -p ${PYPI_ARTIFACTORY_CREDENTIALS_PSW} dist/*
+
+tag-version: # Tag the version and push
+	git tag -a "v${PACKAGE_VERSION}" -m "Tag automatically generated from Jenkins."
+	git push --tags
 
 clean: # Delete build artifacts and do any custom cleanup such as spinning down services
 	@rm -rf format build-doc build-package integration .pytest_cache

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -70,6 +70,7 @@ build-env: # Make a new conda environment
 format: setup.py pyproject.toml $(MAKE_SOURCES) # Run the code formatter and import sorter
 	isort $(LOCATIONS)
 	black $(LOCATIONS)
+	@echo "Ignore, Created by Makefile, `date`" > $@
 
 lint: # Check for formatting errors
 	isort $(LOCATIONS) --check --verbose --only-modified --diff
@@ -78,6 +79,7 @@ lint: # Check for formatting errors
 
 build-doc: $(MAKE_SOURCES) # Build the Sphinx docs
 	$(MAKE) -C docs/ html
+	@echo "Ignore, Created by Makefile, `date`" > $@
 
 deploy-doc: # Deploy the Sphinx docs
 	@[ "${DOCS_ROOT_PATH}" ] && echo "" > /dev/null || ( echo "DOCS_ROOT_PATH is not set"; exit 1 )
@@ -89,6 +91,7 @@ deploy-doc: # Deploy the Sphinx docs
 build-package: $(MAKE_SOURCES) # Build the package as a pip wheel
 	pip install build
 	python -m build
+	@echo "Ignore, Created by Makefile, `date`" > $@
 
 deploy-package-artifactory: # Deploy the package to Artifactory
 	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_USR}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_USR is not set"; exit 1 )

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -71,6 +71,11 @@ format: setup.py pyproject.toml $(MAKE_SOURCES) # Run the code formatter and imp
 	isort $(LOCATIONS)
 	black $(LOCATIONS)
 
+lint: # Check for formatting errors
+	isort $(LOCATIONS) --check --verbose --only-modified --diff
+	black $(LOCATIONS) --check --diff
+
+
 build-doc: $(MAKE_SOURCES) # Build the Sphinx docs
 	$(MAKE) -C docs/ html
 

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -63,13 +63,11 @@ install-upstream-deps: # Install upstream dependencies
 	@echo "----------------------------------------"
 	@sh $(UTILS_DIR)/resources/scripts/install_dependency_branch.sh $(DEPENDENCY_NAME) $(BRANCH_NAME) $(WORKFLOW)
 
-create-env: ## Create a new conda environment
-	$(if $(ENV_NAME),,$(error ENV_NAME is not set. Usage: make create-env ENV_NAME=your_env_name))
-	conda create -n $(ENV_NAME) python=${PYTHON_VERSION} --yes
+create-env: ## Create a new conda environment. Specify env name with CONDA_ENV_NAME. Default env name is PACKAGE_NAME_PYTHON_VERSION.
+	conda create ${CONDA_ENV_CREATION_FLAG} python=${PYTHON_VERSION} --yes
 
-build-env: ## Create environment and install packages
-	$(if $(ENV_NAME),,$(error ENV_NAME is not set. Usage: make build-env ENV_NAME=your_env_name))
-	make create-env ENV_NAME=$(ENV_NAME)
+build-env: ## Create environment and install packages. Specify env name with CONDA_ENV_NAME. Default env name is PACKAGE_NAME_PYTHON_VERSION.
+	make create-env CONDA_ENV_NAME=$(CONDA_ENV_NAME)
 	conda run -n $(ENV_NAME) make install
 
 format: setup.py pyproject.toml $(MAKE_SOURCES) # Run the code formatter and import sorter

--- a/resources/makefiles/test.mk
+++ b/resources/makefiles/test.mk
@@ -6,12 +6,16 @@ endef
 all-tests: $(MAKE_SOURCES) # Run all tests
 	export COVERAGE_FILE=./output/.coverage && \
 	pytest -vvv $(if $(RUNSLOW),--runslow,) --cov --cov-report term --cov-report html:./output/htmlcov_tests tests/
+	@echo "Ignore, Created by Makefile, `date`" > $@
 
 e2e: $(MAKE_SOURCES) # Run end-to-end tests
 	$(call test,e2e)
+	@echo "Ignore, Created by Makefile, `date`" > $@
 
 integration: $(MAKE_SOURCES) # Run integration tests
 	$(call test,integration)
+	@echo "Ignore, Created by Makefile, `date`" > $@
 
 unit: $(MAKE_SOURCES) # Run unit tests
 	$(call test,unit)
+	@echo "Ignore, Created by Makefile, `date`" > $@

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -144,7 +144,7 @@ def call(Map config = [:]){
                         // The env should have been cleaned out after the last build, but delete it again
                         // here just to be safe.
                         sh "rm -rf ${CONDA_ENV_PATH}"
-                        sh "${ACTIVATE_BASE} && make build-env PYTHON_VERSION=${PYTHON_VERSION}"
+                        sh "${ACTIVATE_BASE} && make create-env ENV_NAME=${CONDA_ENV_NAME} PYTHON_VERSION=${PYTHON_VERSION}"
                         // open permissions for test users to create file in workspace
                         sh "chmod 777 ${WORKSPACE}"
                       }

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -144,7 +144,7 @@ def call(Map config = [:]){
                         // The env should have been cleaned out after the last build, but delete it again
                         // here just to be safe.
                         sh "rm -rf ${CONDA_ENV_PATH}"
-                        sh "${ACTIVATE_BASE} && make create-env ENV_NAME=${CONDA_ENV_NAME} PYTHON_VERSION=${PYTHON_VERSION}"
+                        sh "${ACTIVATE_BASE} && make create-env PYTHON_VERSION=${PYTHON_VERSION}"
                         // open permissions for test users to create file in workspace
                         sh "chmod 777 ${WORKSPACE}"
                       }

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -159,8 +159,8 @@ def call(Map config = [:]){
                         }
                       }
 
-                      stage("Format - Python ${pythonVersion}") {
-                        sh "${ACTIVATE} && make format"
+                      stage("Check Formatting - Python ${pythonVersion}") {
+                        sh "${ACTIVATE} && make lint"
                       }
 
                       stage("Run Tests - Python ${pythonVersion}") {


### PR DESCRIPTION
## Allow GBD_access to run
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, POC, refactor, 
                   revert, test, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5789

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
these are several changes to allow gbd_access to run on the shared pipeline, plus a couple other expediencies.

mostly adding the deploy steps from gbd access
making the all-in-one build-env
making the formatting check actually be a check instead of *doing* the format, a distinction which must have gotten lost in the shuffle.
add back some >@ statements in the makefile so we can track when files have changed (e.g. whether to actually run duplicative commands)
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->


