### PR TITLE
Add doc-test back

### DIFF
--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -77,7 +77,10 @@ lint: # Check for formatting errors
 	isort $(LOCATIONS) --check --verbose --only-modified --diff
 	black $(LOCATIONS) --check --diff
 
-build-doc: $(MAKE_SOURCES) # Build the Sphinx docs
+test-doc: $(MAKE_SOURCES) # Test docs
+	$(MAKE) doctest -C docs/
+
+build-doc: $(MAKE_SOURCES) # Build the docs
 	$(MAKE) -C docs/ html
 	@echo "Ignore, Created by Makefile, `date`" > $@
 

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -207,6 +207,9 @@ def call(Map config = [:]){
                             stage("Build Docs - Python ${pythonVersion}") {
                               sh "${ACTIVATE} && make build-doc"
                             }
+                            stage("Test Docs - Python ${pythonVersion}") {
+                              sh "${ACTIVATE} && make test-doc"
+                            }
                           }
 
                         stage("Build and Deploy - Python ${pythonVersion}") {


### PR DESCRIPTION
## Add doc-test back
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, POC, refactor, 
                   revert, test, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5992

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
We're doing doc builds, but not the doc tests, which were in the github build. This is a dropped ball to pick back up. Add the doc tests back under the doc builds
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tested on vivarium. will set the nightly jenkins to this branch before merging.
