### PR TITLE
Allow for simpler doc-only builds

### DIFF
--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -51,7 +51,7 @@ debug: # Print debug information (environment variables)
 install: ## Install setuptools, package, and build utilities
 	pip install uv
 	uv pip install --upgrade pip setuptools 
-	uv pip install -e .[DEV] --extra-index-url ${IHME_PYPI}simple/ --index-strategy unsafe-best-match
+	uv pip install -e .[${ENV_REQS:=dev}] --extra-index-url ${IHME_PYPI}simple/ --index-strategy unsafe-best-match
 
 install-upstream-deps: # Install upstream dependencies
 	@echo "Contents of install_dependency_branch.sh"

--- a/vars/build_stages.groovy
+++ b/vars/build_stages.groovy
@@ -52,9 +52,10 @@ def buildEnvironment() {
     }
 }
 
-def installPackage() {
+def installPackage(String env_name = "") {
+    env_name = env_name ? "[${env_name}]" : ""
     stage("Install Package - Python ${PYTHON_VERSION}") {
-        sh "${ACTIVATE} && make install && pip install ."
+        sh "${ACTIVATE} && make install && pip install .${env_name}"
     }
 }
 

--- a/vars/build_stages.groovy
+++ b/vars/build_stages.groovy
@@ -52,10 +52,10 @@ def buildEnvironment() {
     }
 }
 
-def installPackage(String env_name = "") {
-    env_name = env_name ? "[${env_name}]" : ""
+def installPackage(String env_reqs = "") {
+    env_reqs = env_reqs ? "ENV_REQS=${env_reqs}" : ""
     stage("Install Package - Python ${PYTHON_VERSION}") {
-        sh "${ACTIVATE} && make install && pip install .${env_name}"
+        sh "${ACTIVATE} && make install ${env_reqs} && pip install ."
     }
 }
 

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -1,0 +1,31 @@
+def call() {
+    // Check if this is a PR build by looking for CHANGE_TARGET
+    if (env.CHANGE_TARGET) {
+        // Get the list of changed files
+        def changedFiles = sh(
+            script: "git diff --name-only origin/${env.CHANGE_TARGET}..HEAD || echo ''",
+            returnStdout: true
+        ).trim()
+
+        // If no files are found (which shouldn't happen), return false
+        if (changedFiles == '') {
+            return false
+        }
+
+        // Check if all changed files are within the docs/ directory
+        def hasNonDocChanges = sh(
+            script: """
+                git diff --name-only origin/${env.CHANGE_TARGET}..HEAD |
+                grep -v '^docs/' |
+                wc -l || echo '0'
+            """,
+            returnStdout: true
+        ).trim().toInteger() > 0
+
+        // Return true if there are no non-doc changes
+        return !hasNonDocChanges
+    } else {
+        // Not a PR build, so return false
+        return false
+    }
+}

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -3,8 +3,9 @@ def call() {
     echo "${env.CHANGE_TARGET}"
     if (env.CHANGE_TARGET) {
         // Get the list of changed files
+        // def branch = sh(script: "echo ${GIT_BRANCH} | rev | cut -d '/' -f1 | rev", returnStdout: true).trim()
         def changedFiles = sh(
-            script: "git diff --name-only origin/${env.CHANGE_TARGET}..HEAD || echo ''",
+            script: "git diff --name-only origin/${env.CHANGE_TARGET}..${GIT_BRANCH} || echo ''",
             returnStdout: true
         ).trim()
         echo "Changed files: ${changedFiles}"
@@ -16,7 +17,7 @@ def call() {
         // Check if all changed files are within the docs/ directory
         def hasNonDocChanges = sh(
             script: """
-                git diff --name-only origin/${env.CHANGE_TARGET}..HEAD |
+                git diff --name-only origin/${env.CHANGE_TARGET}..${GIT_BRANCH} |
                 grep -v '^docs/' |
                 wc -l || echo '0'
             """,

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -2,11 +2,11 @@ def call() {
     // Check if this is a PR build by looking for CHANGE_TARGET
     echo "${env.CHANGE_TARGET}"
     if (env.CHANGE_TARGET) {
-        sh(script: "git branch -a", returnStdout: true)
+        sh(script: "git branch -a", returnStdout: false
         // Fetch to ensure we get target branch
         sh(script: "git fetch --no-tags origin ${env.CHANGE_TARGET} || true", returnStdout: false)
         // Get the list of changed files
-        sh(script: "git branch -a", returnStdout: true)
+        sh(script: "git branch -a", returnStdout: false)
         def changedFiles = sh(
             script: "git diff --name-only origin/${env.CHANGE_TARGET} || echo ''",
             returnStdout: true

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -2,9 +2,11 @@ def call() {
     // Check if this is a PR build by looking for CHANGE_TARGET
     echo "${env.CHANGE_TARGET}"
     if (env.CHANGE_TARGET) {
+        sh(script: "git branch -a", returnStdout: true)
         // Fetch to ensure we get target branch
         sh(script: "git fetch --no-tags origin ${env.CHANGE_TARGET} || true", returnStdout: false)
         // Get the list of changed files
+        sh(script: "git branch -a", returnStdout: true)
         def changedFiles = sh(
             script: "git diff --name-only origin/${env.CHANGE_TARGET} || echo ''",
             returnStdout: true

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -4,7 +4,8 @@ def call() {
     if (env.CHANGE_TARGET) {
         sh(script: "git branch -a", returnStdout: false)
         // Fetch to ensure we get target branch
-        sh(script: "git fetch --no-tags origin ${env.CHANGE_TARGET} || true", returnStdout: false)
+        sh(script: "git fetch --no-tags --force --progress +refs/heads/${env.CHANGE_TARGET}:refs/remotes/origin/${env.CHANGE_TARGET}", returnStdout: false)
+
         // Get the list of changed files
         sh(script: "git branch -a", returnStdout: false)
         def changedFiles = sh(

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -4,7 +4,7 @@ def call() {
     if (env.CHANGE_TARGET) {
         // Get the list of changed files
         def changedFiles = sh(
-            script: "git diff --name-only origin/${env.CHANGE_TARGET}..${CHANGE_BRANCH} || echo ''",
+            script: "git diff --name-only origin/${env.CHANGE_TARGET}..HEAD || echo ''",
             returnStdout: true
         ).trim()
         echo "Changed files: ${changedFiles}"
@@ -16,7 +16,7 @@ def call() {
         // Check if all changed files are within the docs/ directory
         def hasNonDocChanges = sh(
             script: """
-                git diff --name-only origin/${env.CHANGE_TARGET}..${CHANGE_BRANCH} |
+                git diff --name-only origin/${env.CHANGE_TARGET}..HEAD |
                 grep -v '^docs/' |
                 wc -l || echo '0'
             """,

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -4,7 +4,7 @@ def call() {
     if (env.CHANGE_TARGET) {
         sh(script: "git branch -a", returnStdout: false)
         // Fetch to ensure we get target branch
-        sh(script: "git fetch --no-tags --force --progress +refs/heads/${env.CHANGE_TARGET}:refs/remotes/origin/${env.CHANGE_TARGET}", returnStdout: false)
+        sh(script: "git fetch --no-tags --force --progress ${GIT_URL} +refs/heads/${env.CHANGE_TARGET}:refs/remotes/origin/${env.CHANGE_TARGET}", returnStdout: false)
 
         // Get the list of changed files
         sh(script: "git branch -a", returnStdout: false)

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -3,9 +3,8 @@ def call() {
     echo "${env.CHANGE_TARGET}"
     if (env.CHANGE_TARGET) {
         // Get the list of changed files
-        def branch = sh(script: "echo ${GIT_BRANCH} | rev | cut -d '/' -f1 | rev", returnStdout: true).trim()
         def changedFiles = sh(
-            script: "git diff --name-only origin/${env.CHANGE_TARGET}..{$branch} || echo ''",
+            script: "git diff --name-only origin/${env.CHANGE_TARGET}..HEAD || echo ''",
             returnStdout: true
         ).trim()
         echo "Changed files: ${changedFiles}"
@@ -17,7 +16,7 @@ def call() {
         // Check if all changed files are within the docs/ directory
         def hasNonDocChanges = sh(
             script: """
-                git diff --name-only origin/${env.CHANGE_TARGET}..{$branch} |
+                git diff --name-only origin/${env.CHANGE_TARGET}..HEAD |
                 grep -v '^docs/' |
                 wc -l || echo '0'
             """,

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -1,18 +1,13 @@
 def call() {
     // Check if this is a PR build by looking for CHANGE_TARGET
-    echo "${env.CHANGE_TARGET}"
     if (env.CHANGE_TARGET) {
-        sh(script: "git branch -a", returnStdout: false)
         // Fetch to ensure we get target branch
         sh(script: "git fetch --no-tags --force --progress ${env.GIT_URL} +refs/heads/${env.CHANGE_TARGET}:refs/remotes/origin/${env.CHANGE_TARGET}", returnStdout: false)
 
-        // Get the list of changed files
-        sh(script: "git branch -a", returnStdout: false)
         def changedFiles = sh(
             script: "git diff --name-only origin/${env.CHANGE_TARGET} || echo ''",
             returnStdout: true
         ).trim()
-        echo "Changed files: ${changedFiles}"
         // If no files are found (which shouldn't happen), return false
         if (changedFiles == '') {
             return false
@@ -27,7 +22,6 @@ def call() {
             """,
             returnStdout: true
         ).trim().toInteger() > 0
-        echo "Has non-doc changes: ${hasNonDocChanges}"
         // Return true if there are no non-doc changes
         return !hasNonDocChanges
     } else {

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -4,7 +4,7 @@ def call() {
     if (env.CHANGE_TARGET) {
         // Get the list of changed files
         def changedFiles = sh(
-            script: "git diff --name-only origin/${env.CHANGE_TARGET}..HEAD || echo ''",
+            script: "git diff --name-only origin/${env.CHANGE_TARGET} || echo ''",
             returnStdout: true
         ).trim()
         echo "Changed files: ${changedFiles}"
@@ -16,7 +16,7 @@ def call() {
         // Check if all changed files are within the docs/ directory
         def hasNonDocChanges = sh(
             script: """
-                git diff --name-only origin/${env.CHANGE_TARGET}..HEAD |
+                git diff --name-only origin/${env.CHANGE_TARGET} |
                 grep -v '^docs/' |
                 wc -l || echo '0'
             """,

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -4,7 +4,7 @@ def call() {
     if (env.CHANGE_TARGET) {
         // Get the list of changed files
         def changedFiles = sh(
-            script: "git diff --name-only origin/${env.CHANGE_TARGET} || echo ''",
+            script: "git diff --name-only refs/remotes/origin/${env.CHANGE_TARGET} || echo ''",
             returnStdout: true
         ).trim()
         echo "Changed files: ${changedFiles}"

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -2,7 +2,7 @@ def call() {
     // Check if this is a PR build by looking for CHANGE_TARGET
     echo "${env.CHANGE_TARGET}"
     if (env.CHANGE_TARGET) {
-        sh(script: "git branch -a", returnStdout: false
+        sh(script: "git branch -a", returnStdout: false)
         // Fetch to ensure we get target branch
         sh(script: "git fetch --no-tags origin ${env.CHANGE_TARGET} || true", returnStdout: false)
         // Get the list of changed files

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -1,12 +1,13 @@
 def call() {
     // Check if this is a PR build by looking for CHANGE_TARGET
+    echo "${env.CHANGE_TARGET}"
     if (env.CHANGE_TARGET) {
         // Get the list of changed files
         def changedFiles = sh(
             script: "git diff --name-only origin/${env.CHANGE_TARGET}..HEAD || echo ''",
             returnStdout: true
         ).trim()
-
+        echo "Changed files: ${changedFiles}"
         // If no files are found (which shouldn't happen), return false
         if (changedFiles == '') {
             return false
@@ -21,7 +22,7 @@ def call() {
             """,
             returnStdout: true
         ).trim().toInteger() > 0
-
+        echo "Has non-doc changes: ${hasNonDocChanges}"
         // Return true if there are no non-doc changes
         return !hasNonDocChanges
     } else {

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -4,7 +4,7 @@ def call() {
     if (env.CHANGE_TARGET) {
         sh(script: "git branch -a", returnStdout: false)
         // Fetch to ensure we get target branch
-        sh(script: "git fetch --no-tags --force --progress ${GIT_URL} +refs/heads/${env.CHANGE_TARGET}:refs/remotes/origin/${env.CHANGE_TARGET}", returnStdout: false)
+        sh(script: "git fetch --no-tags --force --progress ${env.GIT_URL} +refs/heads/${env.CHANGE_TARGET}:refs/remotes/origin/${env.CHANGE_TARGET}", returnStdout: false)
 
         // Get the list of changed files
         sh(script: "git branch -a", returnStdout: false)

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -2,9 +2,11 @@ def call() {
     // Check if this is a PR build by looking for CHANGE_TARGET
     echo "${env.CHANGE_TARGET}"
     if (env.CHANGE_TARGET) {
+        // Fetch to ensure we get target branch
+        sh(script: "git fetch --no-tags origin ${env.CHANGE_TARGET} || true", returnStdout: false)
         // Get the list of changed files
         def changedFiles = sh(
-            script: "git diff --name-only refs/remotes/origin/${env.CHANGE_TARGET} || echo ''",
+            script: "git diff --name-only origin/${env.CHANGE_TARGET} || echo ''",
             returnStdout: true
         ).trim()
         echo "Changed files: ${changedFiles}"

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -3,9 +3,9 @@ def call() {
     echo "${env.CHANGE_TARGET}"
     if (env.CHANGE_TARGET) {
         // Get the list of changed files
-        // def branch = sh(script: "echo ${GIT_BRANCH} | rev | cut -d '/' -f1 | rev", returnStdout: true).trim()
+        def branch = sh(script: "echo ${GIT_BRANCH} | rev | cut -d '/' -f1 | rev", returnStdout: true).trim()
         def changedFiles = sh(
-            script: "git diff --name-only origin/${env.CHANGE_TARGET}..${GIT_BRANCH} || echo ''",
+            script: "git diff --name-only origin/${env.CHANGE_TARGET}..{$branch} || echo ''",
             returnStdout: true
         ).trim()
         echo "Changed files: ${changedFiles}"
@@ -17,7 +17,7 @@ def call() {
         // Check if all changed files are within the docs/ directory
         def hasNonDocChanges = sh(
             script: """
-                git diff --name-only origin/${env.CHANGE_TARGET}..${GIT_BRANCH} |
+                git diff --name-only origin/${env.CHANGE_TARGET}..{$branch} |
                 grep -v '^docs/' |
                 wc -l || echo '0'
             """,

--- a/vars/is_doc_only_change.groovy
+++ b/vars/is_doc_only_change.groovy
@@ -4,7 +4,7 @@ def call() {
     if (env.CHANGE_TARGET) {
         // Get the list of changed files
         def changedFiles = sh(
-            script: "git diff --name-only origin/${env.CHANGE_TARGET}..HEAD || echo ''",
+            script: "git diff --name-only origin/${env.CHANGE_TARGET}..${CHANGE_BRANCH} || echo ''",
             returnStdout: true
         ).trim()
         echo "Changed files: ${changedFiles}"
@@ -16,7 +16,7 @@ def call() {
         // Check if all changed files are within the docs/ directory
         def hasNonDocChanges = sh(
             script: """
-                git diff --name-only origin/${env.CHANGE_TARGET}..HEAD |
+                git diff --name-only origin/${env.CHANGE_TARGET}..${CHANGE_BRANCH} |
                 grep -v '^docs/' |
                 wc -l || echo '0'
             """,

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -125,7 +125,8 @@ def call(Map config = [:]){
                       load_shared_files()
                       buildStages.runDebugInfo()
                       if (IS_DOC_ONLY_CHANGE.toBoolean() == true) {
-                        buildStages.buildEnvironment("doc")
+                        buildStages.buildEnvironment()
+                        buildStages.installPackage("doc")
                         buildStages.testDocs()
                       } else {
                         buildStages.buildEnvironment()

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -51,6 +51,7 @@ def call(Map config = [:]){
         // Jenkins commands run in separate processes, so need to activate the environment every
         // time we run pip, poetry, etc.
         ACTIVATE_BASE = "source ${CONDA_BIN_PATH}/activate &> /dev/null"
+        IS_DOC_ONLY_CHANGE = "${is_doc_only_change()}"
     }
 
     agent { label "coordinator" }
@@ -127,26 +128,31 @@ def call(Map config = [:]){
                       checkout scm
                       load_shared_files()
                       buildStages.runDebugInfo()
-                      buildStages.buildEnvironment()
-                      buildStages.installPackage()
-                      buildStages.installDependencies(upstream_repos)
-                      buildStages.checkFormatting()
-                      buildStages.runTests(test_types)
+                      if (IS_DOC_ONLY_CHANGE.toBoolean()) {
+                        buildStages.buildEnvironment("doc")
+                        buildStages.testDocs()
+                      } else {
+                        buildStages.buildEnvironment()
+                        buildStages.installPackage()
+                        buildStages.installDependencies(upstream_repos)
+                        buildStages.checkFormatting()
+                        buildStages.runTests(test_types)
 
-                      if (PYTHON_VERSION == PYTHON_DEPLOY_VERSION) {
-                        if (config?.skip_doc_build != true) {
-                          buildStages.testDocs()
-                        }
-                        
-                        stage("Build and Deploy - Python ${pythonVersion}") {
-                          if ((config?.deployable == true) &&
-                            !env.IS_CRON.toBoolean() &&
-                            !params.SKIP_DEPLOY &&
-                            (env.BRANCH == "main")) {
-                            buildStages.deployPackage()
+                        if (PYTHON_VERSION == PYTHON_DEPLOY_VERSION) {
+                          if (config?.skip_doc_build != true) {
+                            buildStages.testDocs()
+                          }
+                          
+                          stage("Build and Deploy - Python ${pythonVersion}") {
+                            if ((config?.deployable == true) &&
+                              !env.IS_CRON.toBoolean() &&
+                              !params.SKIP_DEPLOY &&
+                              (env.BRANCH == "main")) {
+                              buildStages.deployPackage()
 
-                            if (config?.skip_doc_build != true) {
-                              buildStages.deployDocs()
+                              if (config?.skip_doc_build != true) {
+                                buildStages.deployDocs()
+                              }
                             }
                           }
                         }

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -51,6 +51,7 @@ def call(Map config = [:]){
         // Jenkins commands run in separate processes, so need to activate the environment every
         // time we run pip, poetry, etc.
         ACTIVATE_BASE = "source ${CONDA_BIN_PATH}/activate &> /dev/null"
+        IS_DOC_ONLY_CHANGE = "${is_doc_only_change()}"
     }
 
     agent { label "coordinator" }
@@ -123,7 +124,7 @@ def call(Map config = [:]){
                       checkout scm
                       load_shared_files()
                       buildStages.runDebugInfo()
-                      if (is_doc_only_change() == true) {
+                      if (IS_DOC_ONLY_CHANGE.toBoolean() == true) {
                         buildStages.buildEnvironment()
                         buildStages.installPackage("doc")
                         buildStages.testDocs()

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -51,7 +51,6 @@ def call(Map config = [:]){
         // Jenkins commands run in separate processes, so need to activate the environment every
         // time we run pip, poetry, etc.
         ACTIVATE_BASE = "source ${CONDA_BIN_PATH}/activate &> /dev/null"
-        IS_DOC_ONLY_CHANGE = "${is_doc_only_change()}"
     }
 
     agent { label "coordinator" }
@@ -124,7 +123,7 @@ def call(Map config = [:]){
                       checkout scm
                       load_shared_files()
                       buildStages.runDebugInfo()
-                      if (IS_DOC_ONLY_CHANGE.toBoolean() == true) {
+                      if (is_doc_only_change() == true) {
                         buildStages.buildEnvironment()
                         buildStages.installPackage("doc")
                         buildStages.testDocs()

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -59,10 +59,6 @@ def call(Map config = [:]){
     options {
       // Keep 100 old builds.
       buildDiscarder logRotator(numToKeepStr: "100")
-      
-      // Wait 60 seconds before starting the build.
-      // If another commit enters the build queue in this time, the first build will be discarded.
-      quietPeriod(60)
 
       // Fail immediately if any part of a parallel stage fails
       parallelsAlwaysFailFast()

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -124,7 +124,7 @@ def call(Map config = [:]){
                       checkout scm
                       load_shared_files()
                       buildStages.runDebugInfo()
-                      if (IS_DOC_ONLY_CHANGE.toBoolean()) {
+                      if (IS_DOC_ONLY_CHANGE.toBoolean() == true) {
                         buildStages.buildEnvironment("doc")
                         buildStages.testDocs()
                       } else {

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -125,6 +125,7 @@ def call(Map config = [:]){
                       load_shared_files()
                       buildStages.runDebugInfo()
                       if (IS_DOC_ONLY_CHANGE.toBoolean() == true) {
+                        echo "This is a doc-only change. Skipping everything except doc build and doc tests."
                         buildStages.buildEnvironment()
                         buildStages.installPackage("doc")
                         buildStages.testDocs()

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -23,7 +23,7 @@ def call(Map config = [:]){
   // raise an error if test_types is not a subset of  ['e2e', 'unit', 'integration']
   if (!test_types.every { ['all-tests', 'e2e', 'unit', 'integration'].contains(it) }) {
     throw new IllegalArgumentException("test_types must be a subset of ['all-tests', 'e2e', 'unit', 'integration']")
-}
+  }
   // Allow for building conda env on shared fs if required
   conda_env_name = config.use_shared_fs ? "${env.JOB_NAME.replaceAll('/', '-')}-${BUILD_NUMBER}" : "${env.JOB_NAME}-${BUILD_NUMBER}"
   conda_env_dir = config.use_shared_fs ? "/mnt/team/simulation_science/priv/engineering/tests/venv" : "/tmp"

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -37,7 +37,7 @@ def call(Map config = [:]){
     environment {
         IS_CRON = "${currentBuild.buildCauses.toString().contains('TimerTrigger')}"
         // defaults for conda and pip are a local directory /svc-simsci for improved speed.
-        // In the past, we used /ihme/code/* on the NFS (which is slower)d
+        // In the past, we used /ihme/code/* on the NFS (which is slower)
         shared_path="/svc-simsci"
         // Get the branch being built and strip everything but the text after the last "/"
         BRANCH = sh(script: "echo ${GIT_BRANCH} | rev | cut -d '/' -f1 | rev", returnStdout: true).trim()

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -37,7 +37,7 @@ def call(Map config = [:]){
     environment {
         IS_CRON = "${currentBuild.buildCauses.toString().contains('TimerTrigger')}"
         // defaults for conda and pip are a local directory /svc-simsci for improved speed.
-        // In the past, we used /ihme/code/* on the NFS (which is slower)
+        // In the past, we used /ihme/code/* on the NFS (which is slower)d
         shared_path="/svc-simsci"
         // Get the branch being built and strip everything but the text after the last "/"
         BRANCH = sh(script: "echo ${GIT_BRANCH} | rev | cut -d '/' -f1 | rev", returnStdout: true).trim()
@@ -51,6 +51,7 @@ def call(Map config = [:]){
         // Jenkins commands run in separate processes, so need to activate the environment every
         // time we run pip, poetry, etc.
         ACTIVATE_BASE = "source ${CONDA_BIN_PATH}/activate &> /dev/null"
+        IS_DOC_ONLY_CHANGE = "${is_doc_only_change()}"
     }
 
     agent { label "coordinator" }
@@ -58,10 +59,6 @@ def call(Map config = [:]){
     options {
       // Keep 100 old builds.
       buildDiscarder logRotator(numToKeepStr: "100")
-      
-      // Wait 60 seconds before starting the build.
-      // If another commit enters the build queue in this time, the first build will be discarded.
-      quietPeriod(60)
 
       // Fail immediately if any part of a parallel stage fails
       parallelsAlwaysFailFast()
@@ -128,25 +125,31 @@ def call(Map config = [:]){
                       load_shared_files()
                       buildStages.runDebugInfo()
                       buildStages.buildEnvironment()
-                      buildStages.installPackage()
-                      buildStages.installDependencies(upstream_repos)
-                      buildStages.checkFormatting()
-                      buildStages.runTests(test_types)
 
-                      if (PYTHON_VERSION == PYTHON_DEPLOY_VERSION) {
-                        if (config?.skip_doc_build != true) {
-                          buildStages.testDocs()
-                        }
-                        
-                        stage("Build and Deploy - Python ${pythonVersion}") {
-                          if ((config?.deployable == true) &&
-                            !env.IS_CRON.toBoolean() &&
-                            !params.SKIP_DEPLOY &&
-                            (env.BRANCH == "main")) {
-                              buildStages.deployPackage()
+                      if IS_DOC_ONLY_CHANGE.toBoolean() {
+                        buildStages.installPackage("doc")
+                        buildStages.testDocs()
+                      } else {
+                        buildStages.installPackage()
+                        buildStages.installDependencies(upstream_repos)
+                        buildStages.checkFormatting()
+                        buildStages.runTests(test_types)
 
-                            if (config?.skip_doc_build != true) {
-                              buildStages.deployDocs()
+                        if (PYTHON_VERSION == PYTHON_DEPLOY_VERSION) {
+                          if (config?.skip_doc_build != true) {
+                            buildStages.testDocs()
+                          }
+                          
+                          stage("Build and Deploy - Python ${pythonVersion}") {
+                            if ((config?.deployable == true) &&
+                              !env.IS_CRON.toBoolean() &&
+                              !params.SKIP_DEPLOY &&
+                              (env.BRANCH == "main")) {
+                                buildStages.deployPackage()
+
+                              if (config?.skip_doc_build != true) {
+                                buildStages.deployDocs()
+                              }
                             }
                           }
                         }


### PR DESCRIPTION
## Allow for simpler doc-only builds
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, POC, refactor, 
                   revert, test, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5995

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This change allows for a category of "doc-only" builds, which will only run the doc build and doc test stages before exiting. We also only install the packages required for docs, i.e. `.[doc]` in the setup.py. I am adding a separate change to get around installation of graphviz backend in easylink, which is at the moment extraneous for doc builds.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

