### PR TITLE
Fail on Warning

### DIFF
--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -81,7 +81,7 @@ test-doc: $(MAKE_SOURCES) # Test docs
 	$(MAKE) doctest -C docs/
 
 build-doc: $(MAKE_SOURCES) # Build the docs
-	$(MAKE) -C -W docs/ html
+	$(MAKE) -W -C docs/ html
 	@echo "Ignore, Created by Makefile, `date`" > $@
 
 deploy-doc: # Deploy the Sphinx docs

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -81,7 +81,7 @@ test-doc: $(MAKE_SOURCES) # Test docs
 	$(MAKE) doctest -C docs/
 
 build-doc: $(MAKE_SOURCES) # Build the docs
-	$(MAKE) -C docs/ html SPHINXOPTS="-W"
+	$(MAKE) -C docs/ html SPHINXOPTS="-T -W --keep-going"
 	@echo "Ignore, Created by Makefile, `date`" > $@
 
 deploy-doc: # Deploy the Sphinx docs

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -81,7 +81,7 @@ test-doc: $(MAKE_SOURCES) # Test docs
 	$(MAKE) doctest -C docs/
 
 build-doc: $(MAKE_SOURCES) # Build the docs
-	$(MAKE) -W -C docs/ html
+	$(MAKE) -C docs/ html -W
 	@echo "Ignore, Created by Makefile, `date`" > $@
 
 deploy-doc: # Deploy the Sphinx docs

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -81,7 +81,7 @@ test-doc: $(MAKE_SOURCES) # Test docs
 	$(MAKE) doctest -C docs/
 
 build-doc: $(MAKE_SOURCES) # Build the docs
-	$(MAKE) -C docs/ html
+	$(MAKE) -C docs/ html -W
 	@echo "Ignore, Created by Makefile, `date`" > $@
 
 deploy-doc: # Deploy the Sphinx docs

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -81,7 +81,7 @@ test-doc: $(MAKE_SOURCES) # Test docs
 	$(MAKE) doctest -C docs/
 
 build-doc: $(MAKE_SOURCES) # Build the docs
-	$(MAKE) -C docs/ html -W
+	$(MAKE) -C -W docs/ html
 	@echo "Ignore, Created by Makefile, `date`" > $@
 
 deploy-doc: # Deploy the Sphinx docs

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -81,7 +81,7 @@ test-doc: $(MAKE_SOURCES) # Test docs
 	$(MAKE) doctest -C docs/
 
 build-doc: $(MAKE_SOURCES) # Build the docs
-	$(MAKE) -C docs/ html -W
+	$(MAKE) -C docs/ html SPHINXOPTS="-W"
 	@echo "Ignore, Created by Makefile, `date`" > $@
 
 deploy-doc: # Deploy the Sphinx docs


### PR DESCRIPTION
## Fail on Warning
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, POC, refactor, 
                   revert, test, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5999

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
make jenkins fail on warning for doc builds
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tested that this broke vivarium, and my fix fixed it.
