### PR TITLE
skip tag push for dupe

### DIFF
--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -104,8 +104,13 @@ deploy-package-artifactory: # Deploy the package to Artifactory
 	twine upload --repository-url ${IHME_PYPI} -u ${PYPI_ARTIFACTORY_CREDENTIALS_USR} -p ${PYPI_ARTIFACTORY_CREDENTIALS_PSW} dist/*
 
 tag-version: # Tag the version and push
-	git tag -a "v${PACKAGE_VERSION}" -m "Tag automatically generated from Jenkins."
-	git push --tags
+	@if ! git ls-remote --tags origin | grep -q "refs/tags/v${PACKAGE_VERSION}$$"; then \
+		echo "Creating and pushing tag v${PACKAGE_VERSION}"; \
+		git tag -a "v${PACKAGE_VERSION}" -m "Tag automatically generated from Jenkins."; \
+		git push --tags; \
+	else \
+		echo "Tag v${PACKAGE_VERSION} already exists on remote. Skipping."; \
+	fi
 
 clean: # Delete build artifacts and do any custom cleanup such as spinning down services
 	@rm -rf format build-doc build-package integration .pytest_cache


### PR DESCRIPTION
## skip tag push for dupe
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, POC, refactor, 
                   revert, test, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6012

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Gbd access fails if we push tags when they already exist. this is annoying, because we might make e.g. build changes without updating the changelog. We want to either ALWAYS update the gbd_access changelog, or else skip the tag push when the tag exists already.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
https://jenkins.simsci.ihme.washington.edu/job/stash_repos/job/vivarium_gbd_access/job/main/63/
