### PR TITLE
add new make command to manually deploy

### DIFF
--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -111,9 +111,9 @@ manual-deploy: # Manual deploy to Artifactory
 	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_USR}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_USR is not set, export using simsci artifactory credentials"; exit 1 )
 	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_PSW}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_PSW is not set, export using simsci artifactory credentials"; exit 1 )
 	make build-env
-	make build-package
-	make tag-version
-	make deploy-package-artifactory
+	conda run -n $(CONDA_ENV_NAME) make build-package
+	conda run -n $(CONDA_ENV_NAME) make tag-version
+	conda run -n $(CONDA_ENV_NAME) make deploy-package-artifactory
 
 clean: # Delete build artifacts and do any custom cleanup such as spinning down services
 	@rm -rf format build-doc build-package integration .pytest_cache

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -98,14 +98,22 @@ build-package: $(MAKE_SOURCES) # Build the package as a pip wheel
 	@echo "Ignore, Created by Makefile, `date`" > $@
 
 deploy-package-artifactory: # Deploy the package to Artifactory
-	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_USR}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_USR is not set"; exit 1 )
-	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_PSW}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_PSW is not set"; exit 1 )
+	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_USR}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_USR is not set, export using simsci artifactory credentials"; exit 1 )
+	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_PSW}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_PSW is not set, export using simsci artifactory credentials"; exit 1 )
 	pip install twine
 	twine upload --repository-url ${IHME_PYPI} -u ${PYPI_ARTIFACTORY_CREDENTIALS_USR} -p ${PYPI_ARTIFACTORY_CREDENTIALS_PSW} dist/*
 
 tag-version: # Tag the version and push
 	git tag -a "v${PACKAGE_VERSION}" -m "Tag automatically generated from Jenkins."
 	git push --tags
+
+manual-deploy: # Manual deploy to Artifactory
+	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_USR}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_USR is not set, export using simsci artifactory credentials"; exit 1 )
+	@[ "${PYPI_ARTIFACTORY_CREDENTIALS_PSW}" ] && echo "" > /dev/null || ( echo "PYPI_ARTIFACTORY_CREDENTIALS_PSW is not set, export using simsci artifactory credentials"; exit 1 )
+	make build-env
+	make build-package
+	make tag-version
+	make deploy-package-artifactory
 
 clean: # Delete build artifacts and do any custom cleanup such as spinning down services
 	@rm -rf format build-doc build-package integration .pytest_cache


### PR DESCRIPTION
## add new make command to manually deploy
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, POC, refactor, 
                   revert, test, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6012

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
We wanted to avoid some edge cases in deploying to jenkins; we determined the easiest way would be with a nice manual deploy make command. I tried it out, but obviously didn't get all the way to deploying. I think you need to wrap the called make commands in conda run to get it to run in the right environment
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

