### PR TITLE
fix broken doc stages and makefile target names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.0.1 - 7/25/2025**
+
+  - Bugfix: fix broken doc stages in Jenkins pipeline
+
 **2.0.0 - 7/24/2025**
 
   - Clean up and better document Make files

--- a/vars/build_stages.groovy
+++ b/vars/build_stages.groovy
@@ -7,6 +7,7 @@ def call() {
         installDependencies: this.&installDependencies,
         checkFormatting: this.&checkFormatting,
         runTests: this.&runTests,
+        buildDocs: this.&buildDocs,
         testDocs: this.&testDocs,
         deployPackage: this.&deployPackage,
         deployDocs: this.&deployDocs,
@@ -118,13 +119,13 @@ def runTests(List test_types) {
 
 def buildDocs() {
     stage("Build Docs - Python ${PYTHON_VERSION}") {
-        sh "${ACTIVATE} && make build-doc"
+        sh "${ACTIVATE} && make build-docs"
     }
 }
 
 def testDocs() {
     stage("Test Docs - Python ${PYTHON_VERSION}") {
-        sh "${ACTIVATE} && make test-doc"
+        sh "${ACTIVATE} && make test-docs"
     }
 }
 
@@ -151,7 +152,7 @@ def deployPackage() {
 def deployDocs() {
     stage("Deploy Docs") {
         withEnv(["DOCS_ROOT_PATH=/mnt/team/simulation_science/pub/docs"]) {
-            sh "${ACTIVATE} && make deploy-doc"
+            sh "${ACTIVATE} && make deploy-docs"
         }
     }
 }

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -150,6 +150,7 @@ def call(Map config = [:]){
                       if (IS_DOC_ONLY_CHANGE.toBoolean() == true) {
                         echo "This is a doc-only change. Skipping everything except doc build and doc tests."
                         buildStages.installPackage("docs")
+                        buildStages.buildDocs()
                         buildStages.testDocs()
                       } else {
                         buildStages.installPackage()


### PR DESCRIPTION
## Fix broken doc stages and makefile target names

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

1. I updated the groovy doc functions to use plural "docs" but forgot to update the 
corresponding make target names
2. I added buildDocs to the build_stages.groovy call mapping (since I split it apart
from testDocs())
3. I added buildDocs prior to testDocs in one part I forgot (since I split them)
 
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

