### PR TITLE
check dependencies recursively

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.3.8 - 03/17/26**
+
+   - Check upstream dependencies recursively
+
 **2.3.7 - 03/12/26**
 
    - Validate github repo version prior to deploying

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**2.3.9 - 03/17/26**
+**2.4.0 - 03/19/26**
 
    - Check upstream dependencies recursively
 

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -218,7 +218,7 @@ install-upstream-deps: # Install upstream dependencies
 	@cat $(UTILS_DIR)/resources/scripts/install_dependency_branch.sh
 	@echo
 	@echo "----------------------------------------"
-	@sh $(UTILS_DIR)/resources/scripts/install_dependency_branch.sh $(DEPENDENCY_NAME) $(BRANCH_NAME) $(WORKFLOW)
+	@bash $(UTILS_DIR)/resources/scripts/install_dependency_branch.sh $(DEPENDENCY_NAME) $(BRANCH_NAME) $(WORKFLOW)
 	@echo
 
 .PHONY: format

--- a/resources/scripts/install_dependency_branch.sh
+++ b/resources/scripts/install_dependency_branch.sh
@@ -1,103 +1,318 @@
 #!/bin/bash
 
-# Define variables
-dependency_name=$1
-branch_name=$2
-workflow=$3
-root_dir=$(pwd)
-dependency_branch_name='main'
+# =============================================================================
+# Recursive Upstream Dependency Branch Installer
+# =============================================================================
+#
+# Resolves and installs upstream dependency branches, including transitive
+# dependencies discovered by reading each dependency's Jenkinsfile.
+#
+# For each dependency, the script checks whether a matching branch exists in
+# the dependency's remote repo. If a match is found (non-main), the dependency
+# is cloned and installed from source. The script then recursively inspects
+# that dependency's own Jenkinsfile for *its* upstream_repos and repeats the
+# process, ensuring the entire transitive dependency tree is resolved.
+#
+# Usage (new):
+#   ./install_dependency_branch.sh <dep1> [dep2 ...] [--workflow jenkins|github]
+#
+# Usage (legacy / backward-compatible):
+#   ./install_dependency_branch.sh <dep_name> <branch_name> <workflow>
+#
+# =============================================================================
 
-# Try multiple methods to get the branch name
-if [ -n "$CHANGE_BRANCH" ]; then
-  # Jenkins pull request build
-  branch_name_to_check=$CHANGE_BRANCH
-elif [ -n "$BRANCH_NAME" ]; then
-  # Jenkins branch build
-  branch_name_to_check=$BRANCH_NAME
-elif [ -n "$GITHUB_HEAD_REF" ]; then
-  # GitHub Actions pull request
-  branch_name_to_check=$GITHUB_HEAD_REF
-elif [ -n "$GITHUB_REF_NAME" ]; then
-  # GitHub Actions branch build
-  branch_name_to_check=$GITHUB_REF_NAME
-else
-  # Local development - try to get branch name from git
-  branch_name_to_check=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --abbrev-ref HEAD)
-    
-  # If we're in detached HEAD state and can't determine branch, try to get it from the reflog
-  if [ "$branch_name_to_check" = "HEAD" ]; then
-    # Look for the last branch name in the reflog
-    branch_name_to_check=$(git reflog -1 | grep -o 'from \S*' | cut -d' ' -f2 | sed 's/^origin\///')
-        
-    # If still nothing, fall back to main
-    if [ -z "$branch_name_to_check" ]; then
-      echo "Could not determine branch name, defaulting to main"
-      branch_name_to_check="main"
-      fi
-  fi
-fi
+set -uo pipefail
 
-echo "Determined dependee branch name: ${branch_name_to_check}"
-iterations=0
+# ---- Global state ----
+declare -A REPO_BRANCH_MAP=()   # repo -> resolved branch name
+declare -A RESOLVED_REPOS=()   # repos we've finished resolving (cycle guard)
+declare -a INSTALL_ORDER=()    # repos to install, deepest-first (post-order)
 
-while [ "$branch_name_to_check" != "$dependency_branch_name" ] && [ $iterations -lt 20 ]
-do
-  echo "Checking for ${dependency_name} branch: '${branch_name_to_check}'"
-  if
-    git ls-remote --exit-code \
-    --heads https://github.com/ihmeuw/"${dependency_name}".git "${branch_name_to_check}"
-  then
-    dependency_branch_name=${branch_name_to_check}
-    echo "Found matching dependency branch: ${dependency_branch_name}"
+ROOT_DIR=$(pwd)
+WORKFLOW=""
+
+# ---- Logging helpers ----
+log() { echo "$@"; }
+
+log_indent() {
+  local depth=$1; shift
+  local prefix=""
+  for ((i = 0; i < depth; i++)); do prefix+="  "; done
+  echo "${prefix}$*"
+}
+
+# ---- Determine the current branch name from the environment ----
+determine_branch_to_check() {
+  if [ -n "${CHANGE_BRANCH:-}" ]; then
+    # Jenkins pull request build
+    echo "$CHANGE_BRANCH"
+  elif [ -n "${BRANCH_NAME:-}" ]; then
+    # Jenkins branch build
+    echo "$BRANCH_NAME"
+  elif [ -n "${GITHUB_HEAD_REF:-}" ]; then
+    # GitHub Actions pull request
+    echo "$GITHUB_HEAD_REF"
+  elif [ -n "${GITHUB_REF_NAME:-}" ]; then
+    # GitHub Actions branch build
+    echo "$GITHUB_REF_NAME"
   else
-    echo "Could not find ${dependency_name} branch '${branch_name_to_check}'. Finding parent branch."
-      
-    # Try to find parent branch using git-merge-base and name-rev
-    merge_base=$(git merge-base origin/main HEAD 2>/dev/null)
-    if [ $? -eq 0 ] && [ -n "$merge_base" ]; then
-      echo "Merge base: ${merge_base}"
-      # Get the parent branch name, removing remotes/origin/ prefix and any ^0 suffix
-      branch_name_to_check=$(git name-rev --exclude "tags/*" --refs="refs/remotes/origin/*" --name-only "$merge_base" | \
-        sed -E 's/^(remotes\/)?origin\///' | \
-        sed 's/\^[0-9]*$//')
-      if [ "$branch_name_to_check" = "HEAD" ]; then
-        branch_name_to_check="main"
-      fi
-    else
-      # If merge-base fails, try to get parent from GitHub API if we have a PR number
-      pr_number=$(echo "$branch_name_to_check" | grep -o 'PR-[0-9]*' | cut -d'-' -f2)
-      if [ -n "$pr_number" ] && [ -n "$GITHUB_TOKEN" ]; then
-        base_branch=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-          "https://api.github.com/repos/ihmeuw/$dependency_name/pulls/$pr_number" | \
-          grep '"base": {' -A 3 | grep '"ref":' | cut -d'"' -f4)
-          if [ -n "$base_branch" ]; then
-            branch_name_to_check=$base_branch
-          else
-            branch_name_to_check="main"
-          fi
-      else
-        branch_name_to_check="main"
+    # Local development – try to get branch name from git
+    local branch
+    branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --abbrev-ref HEAD)
+
+    if [ "$branch" = "HEAD" ]; then
+      branch=$(git reflog -1 2>/dev/null | grep -o 'from \S*' | cut -d' ' -f2 | sed 's/^origin\///')
+      if [ -z "$branch" ]; then
+        echo "Could not determine branch name, defaulting to main" >&2
+        echo "main"
+        return
       fi
     fi
-      
-    if [ -z "$branch_name_to_check" ] || [ "$branch_name_to_check" = "undefined" ]; then
-      echo "Could not find parent branch. Will use released version of ${dependency_name}."
-      branch_name_to_check="main"
-    fi
-    echo "Next dependee branch to check: ${branch_name_to_check}"
-    iterations=$((iterations+1))
+    echo "$branch"
   fi
-done
+}
 
-if [ "$workflow" = "github" ]; then
-  echo "${dependency_name}_branch_name=${dependency_branch_name}" >> "$GITHUB_ENV"
-fi
+# ---- Resolve what branch to use for a single dependency ----
+# Walks up the current repo's branch lineage until a matching remote branch is
+# found in the dependency, or falls back to "main".
+# NOTE: All logging goes to stderr so the caller can capture stdout cleanly.
+resolve_branch_for_dep() {
+  local dep=$1
+  local branch_to_check=$2
+  local depth=${3:-0}
+  local resolved="main"
+  local iterations=0
 
-if [ "$dependency_branch_name" != "main" ]; then
-  echo "Cloning ${dependency_name} branch: ${dependency_branch_name}"
-  cd ..
-  git clone --branch="${dependency_branch_name}" https://github.com/ihmeuw/"${dependency_name}".git
-  cd "${dependency_name}" || exit
-  pip install .
-  cd "$root_dir" || exit
-fi
+  local prev_branch_to_check=""
+  while [ "$branch_to_check" != "$resolved" ] && [ $iterations -lt 20 ]; do
+    log_indent "$depth" "Checking for ${dep} branch: '${branch_to_check}'" >&2
+
+    if git ls-remote --exit-code --heads \
+         "https://github.com/ihmeuw/${dep}.git" "$branch_to_check" &>/dev/null; then
+      resolved="$branch_to_check"
+      log_indent "$depth" "Found matching branch: ${resolved}" >&2
+      break
+    else
+      log_indent "$depth" "Branch '${branch_to_check}' not found for ${dep}. Finding parent branch." >&2
+
+      local merge_base
+      merge_base=$(git merge-base origin/main HEAD 2>/dev/null || true)
+      if [ -n "$merge_base" ]; then
+        branch_to_check=$(git name-rev --exclude "tags/*" \
+          --refs="refs/remotes/origin/*" --name-only "$merge_base" | \
+          sed -E 's/^(remotes\/)?origin\///' | \
+          sed -E 's/[~^][0-9]*$//')
+        if [ "$branch_to_check" = "HEAD" ]; then
+          branch_to_check="main"
+        fi
+      else
+        # Fallback: try GitHub API for PR base branch
+        local pr_number
+        pr_number=$(echo "$branch_to_check" | grep -o 'PR-[0-9]*' | cut -d'-' -f2 || true)
+        if [ -n "$pr_number" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+          local base_branch
+          base_branch=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/ihmeuw/${dep}/pulls/${pr_number}" | \
+            grep '"base": {' -A 3 | grep '"ref":' | cut -d'"' -f4 || true)
+          branch_to_check="${base_branch:-main}"
+        else
+          branch_to_check="main"
+        fi
+      fi
+
+      if [ -z "$branch_to_check" ] || [ "$branch_to_check" = "undefined" ]; then
+        branch_to_check="main"
+      fi
+
+      # Avoid infinite loop if parent resolution returns the same branch
+      if [ "$branch_to_check" = "$prev_branch_to_check" ]; then
+        log_indent "$depth" "Parent branch resolution stuck on '${branch_to_check}', falling back to main." >&2
+        branch_to_check="main"
+      fi
+      prev_branch_to_check="$branch_to_check"
+
+      log_indent "$depth" "Next branch to check: ${branch_to_check}" >&2
+      iterations=$((iterations + 1))
+    fi
+  done
+
+  # Return via stdout (caller captures with $())
+  echo "$resolved"
+}
+
+# ---- Fetch upstream_repos from a repo's Jenkinsfile on GitHub ----
+# Does a minimal no-checkout clone to read just the Jenkinsfile, then parses
+# the upstream_repos list from it.
+get_transitive_deps() {
+  local repo=$1
+  local branch=$2
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  local deps=""
+  if git clone --depth=1 --branch="$branch" --no-checkout \
+       "https://github.com/ihmeuw/${repo}.git" "$tmpdir" 2>/dev/null; then
+    # Checkout only the Jenkinsfile
+    git -C "$tmpdir" checkout "$branch" -- Jenkinsfile 2>/dev/null || true
+
+    if [ -f "$tmpdir/Jenkinsfile" ]; then
+      # Extract the upstream_repos value – handles single-line and multi-line
+      deps=$(sed -n '/upstream_repos\s*:/,/]/p' "$tmpdir/Jenkinsfile" | \
+             grep -oE '"[a-zA-Z0-9_-]+"' | \
+             tr -d '"' | \
+             tr '\n' ' ')
+    fi
+  fi
+
+  rm -rf "$tmpdir"
+  echo "$deps"
+}
+
+# ---- Recursively resolve a dependency and its transitive deps ----
+resolve_recursive() {
+  local dep=$1
+  local branch_to_check=$2
+  local depth=${3:-0}
+
+  # Guard against cycles and repeated work
+  if [[ -v RESOLVED_REPOS["$dep"] ]]; then
+    log_indent "$depth" "Already resolved: ${dep} -> ${REPO_BRANCH_MAP[$dep]}"
+    return
+  fi
+  RESOLVED_REPOS["$dep"]=1
+
+  log_indent "$depth" "Resolving: ${dep}"
+
+  # Determine which branch (if any) this dependency has
+  local resolved_branch
+  resolved_branch=$(resolve_branch_for_dep "$dep" "$branch_to_check" "$depth")
+  REPO_BRANCH_MAP["$dep"]="$resolved_branch"
+
+  if [ "$resolved_branch" != "main" ]; then
+    log_indent "$depth" "${dep} -> ${resolved_branch} (will install from source)"
+
+    # Discover transitive dependencies from the dependency's Jenkinsfile
+    log_indent "$depth" "Checking ${dep}'s Jenkinsfile for transitive dependencies..."
+    local transitive_deps
+    transitive_deps=$(get_transitive_deps "$dep" "$resolved_branch")
+
+    if [ -n "$transitive_deps" ]; then
+      log_indent "$depth" "Transitive deps for ${dep}: ${transitive_deps}"
+      for tdep in $transitive_deps; do
+        resolve_recursive "$tdep" "$branch_to_check" $((depth + 1))
+      done
+    else
+      log_indent "$depth" "No transitive dependencies found for ${dep}"
+    fi
+
+    # Post-order: add after transitive deps so deepest deps are installed first
+    INSTALL_ORDER+=("$dep")
+  else
+    log_indent "$depth" "${dep} -> main (using released version)"
+  fi
+}
+
+# ---- Install all resolved non-main dependencies ----
+install_resolved_deps() {
+  echo ""
+  echo "========================================="
+  echo "Dependency Resolution Complete"
+  echo "========================================="
+
+  if [ ${#INSTALL_ORDER[@]} -eq 0 ]; then
+    log "No upstream dependency branches to install (all using released versions)."
+    return
+  fi
+
+  echo "Installation plan (deepest-first order):"
+  for repo in "${INSTALL_ORDER[@]+"${INSTALL_ORDER[@]}"}"; do
+    echo "  - ${repo} @ ${REPO_BRANCH_MAP[$repo]}"
+  done
+  echo ""
+
+  cd ..  # Move to parent of the project root
+
+  for repo in "${INSTALL_ORDER[@]+"${INSTALL_ORDER[@]}"}"; do
+    local branch="${REPO_BRANCH_MAP[$repo]}"
+    if [ -d "$repo" ]; then
+      log "${repo} already cloned – reinstalling..."
+      cd "$repo"
+      pip install .
+      cd ..
+    else
+      log "Cloning and installing ${repo} @ ${branch}..."
+      git clone --branch="$branch" "https://github.com/ihmeuw/${repo}.git"
+      cd "$repo"
+      pip install .
+      cd ..
+    fi
+  done
+
+  cd "$ROOT_DIR"
+}
+
+# ---- Export branch info for CI systems ----
+export_branch_info() {
+  if [ "$WORKFLOW" = "github" ]; then
+    for repo in "${!REPO_BRANCH_MAP[@]}"; do
+      echo "${repo}_branch_name=${REPO_BRANCH_MAP[$repo]}" >> "$GITHUB_ENV"
+    done
+  fi
+}
+
+# ---- Main ----
+main() {
+  local repos=()
+
+  # ---- Argument parsing ----
+  # Legacy format (3 positional args): script.sh <dep> <branch> jenkins|github
+  #   - <branch> is unused (detected from env); kept for backward compatibility.
+  # New format: script.sh <dep1> [dep2 ...] [--workflow jenkins|github]
+  if [ $# -eq 3 ] && { [ "$3" = "jenkins" ] || [ "$3" = "github" ]; }; then
+    # Legacy invocation
+    repos=("$1")
+    WORKFLOW="$3"
+  else
+    while [[ $# -gt 0 ]]; do
+      case $1 in
+        --workflow)
+          WORKFLOW="${2:-}"
+          shift 2
+          ;;
+        *)
+          repos+=("$1")
+          shift
+          ;;
+      esac
+    done
+  fi
+
+  if [ ${#repos[@]} -eq 0 ]; then
+    echo "Usage: $0 <dep1> [dep2 ...] [--workflow jenkins|github]"
+    echo "       $0 <dep_name> <branch_name> <workflow>  (legacy)"
+    exit 1
+  fi
+
+  local branch_to_check
+  branch_to_check=$(determine_branch_to_check)
+  log "Determined branch to check: ${branch_to_check}"
+  echo ""
+
+  if [ "$branch_to_check" = "main" ]; then
+    log "On main branch – all upstream dependencies will use released versions."
+    export_branch_info
+    return
+  fi
+
+  echo "========================================="
+  echo "Resolving dependencies recursively"
+  echo "========================================="
+  for repo in "${repos[@]}"; do
+    resolve_recursive "$repo" "$branch_to_check" 0
+  done
+
+  install_resolved_deps
+  export_branch_info
+}
+
+main "$@"

--- a/resources/scripts/install_dependency_branch.sh
+++ b/resources/scripts/install_dependency_branch.sh
@@ -76,7 +76,7 @@ determine_branch_to_check() {
 # Walks up the current repo's branch lineage until a matching remote branch is
 # found in the dependency, or falls back to "main".
 # NOTE: All logging goes to stderr so the caller can capture stdout cleanly.
-resolve_branch_for_dep() {
+resolve_branch_for_dependency() {
   local dep=$1
   local branch_to_check=$2
   local depth=${3:-0}
@@ -143,7 +143,7 @@ resolve_branch_for_dep() {
 # ---- Fetch upstream_repos from a repo's Jenkinsfile on GitHub ----
 # Does a minimal no-checkout clone to read just the Jenkinsfile, then parses
 # the upstream_repos list from it.
-get_transitive_deps() {
+get_transitive_dependencies() {
   local repo=$1
   local branch=$2
   local tmpdir
@@ -185,7 +185,7 @@ resolve_recursive() {
 
   # Determine which branch (if any) this dependency has
   local resolved_branch
-  resolved_branch=$(resolve_branch_for_dep "$dep" "$branch_to_check" "$depth")
+  resolved_branch=$(resolve_branch_for_dependency "$dep" "$branch_to_check" "$depth")
   REPO_BRANCH_MAP["$dep"]="$resolved_branch"
 
   if [ "$resolved_branch" != "main" ]; then
@@ -194,7 +194,7 @@ resolve_recursive() {
     # Discover transitive dependencies from the dependency's Jenkinsfile
     log_indent "$depth" "Checking ${dep}'s Jenkinsfile for transitive dependencies..."
     local transitive_deps
-    transitive_deps=$(get_transitive_deps "$dep" "$resolved_branch")
+    transitive_deps=$(get_transitive_dependencies "$dep" "$resolved_branch")
 
     if [ -n "$transitive_deps" ]; then
       log_indent "$depth" "Transitive deps for ${dep}: ${transitive_deps}"
@@ -213,7 +213,7 @@ resolve_recursive() {
 }
 
 # ---- Install all resolved non-main dependencies ----
-install_resolved_deps() {
+install_resolved_dependencies() {
   echo ""
   echo "========================================="
   echo "Dependency Resolution Complete"
@@ -311,7 +311,7 @@ main() {
     resolve_recursive "$repo" "$branch_to_check" 0
   done
 
-  install_resolved_deps
+  install_resolved_dependencies
   export_branch_info
 }
 

--- a/vars/build_stages.groovy
+++ b/vars/build_stages.groovy
@@ -85,9 +85,11 @@ def installPackage(String env_reqs = "") {
 
 def installDependencies(List upstream_repos) {
     stage("Install Upstream Dependency Branches - Python ${PYTHON_VERSION}") {
-        sh "chmod +x install_dependency_branch.sh"
-        upstream_repos.each { repo ->
-            sh "${ACTIVATE} && ./install_dependency_branch.sh ${repo} ${GIT_BRANCH} jenkins"
+        if (upstream_repos) {
+            sh "chmod +x install_dependency_branch.sh"
+            sh "${ACTIVATE} && ./install_dependency_branch.sh ${upstream_repos.join(' ')} --workflow jenkins"
+        } else {
+            echo "No upstream repos configured – skipping."
         }
     }
 }


### PR DESCRIPTION
## check dependencies recursively

### Description
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5837

### Changes and notes
Resolve dependencies recursively, and all at once instead of looping through each repo.
Update install_dependency_branch to take in multiple repos as arguments.
Strictly define installation order to be deepest first.
Change from sh call to bash call to allow use of associate arrays (dictionary-like data structure to store information for different repos).
More descriptive logging. 
"Indented" logs, ie logs when resolving recursive repos, get sent to stderr to allow visibility and separation from stdout.

### Testing
Ran the install_dependency_branch passing in main branches and got released branches, duplicated repos and got one repo back, and no repos and got nothing.
Created test branches in VPH, vivarium, and LCT (with LCT removed as a VPH dependency) and checked that we pulled test branch for LCT in Jenkins.

<img width="561" height="346" alt="recursive_dependency_resolution" src="https://github.com/user-attachments/assets/7a7dc071-8f83-43e6-85be-135a1dbae126" />