### PR TITLE
Correctly relocate shared environments

### DIFF
--- a/Jenkinsfile.shared-env
+++ b/Jenkinsfile.shared-env
@@ -334,9 +334,12 @@ def promoteEnvironment(String timestampedPath, String currentPath, String envNam
         # pip/setuptools embed the absolute Python path at install time, which still references
         # the old timestamped directory after the mv. Replace all occurrences with the stable
         # _current path so the scripts can find Python.
+        # IMPORTANT: Only rewrite text files — running sed on binary executables (e.g. python3.11)
+        # corrupts their ELF headers and causes segfaults.
         echo "Rewriting timestamped paths in bin/ scripts..."
-        find "${currentPath}/bin" -maxdepth 1 -type f -exec \
-            sed -i "s|${timestampedPath}|${currentPath}|g" {} +
+        grep -rIl "${timestampedPath}" "${currentPath}/bin" 2>/dev/null | while read -r f; do
+            sed -i "s|${timestampedPath}|${currentPath}|g" "\$f"
+        done
         echo "Path rewriting complete"
         
         # Set permissions - readable by all, writable only by Jenkins

--- a/Jenkinsfile.shared-env
+++ b/Jenkinsfile.shared-env
@@ -330,6 +330,15 @@ def promoteEnvironment(String timestampedPath, String currentPath, String envNam
         mv "${timestampedPath}" "${currentPath}"
         echo "Promoted new environment to current"
         
+        # Rewrite hardcoded timestamped paths in bin/ scripts (shebangs and polyglot wrappers).
+        # pip/setuptools embed the absolute Python path at install time, which still references
+        # the old timestamped directory after the mv. Replace all occurrences with the stable
+        # _current path so the scripts can find Python.
+        echo "Rewriting timestamped paths in bin/ scripts..."
+        find "${currentPath}/bin" -maxdepth 1 -type f -exec \
+            sed -i "s|${timestampedPath}|${currentPath}|g" {} +
+        echo "Path rewriting complete"
+        
         # Set permissions - readable by all, writable only by Jenkins
         chmod -R 755 "${currentPath}"
         


### PR DESCRIPTION
### Description
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6928

### Changes and notes

The `promoteEnvironment` step in the shared environment Jenkins pipeline
was running `sed -i` via `find ... -exec` on every file in `bin/`,
including ELF binaries like `python3.11`. This corrupted their section
headers, causing segfaults for all users of the shared environment.

The fix replaces the blanket `find -exec sed` with `grep -rIl` to
identify only text files containing the timestamped path before
passing them to `sed`. The `-I` flag causes `grep` to skip binary
files.

### Testing

- Verified locally that `grep -rIl` skips ELF binaries
- Confirmed the current shared env has corrupted Python binary
  (`file` reports "missing section headers")