### PR TITLE
Albrja/mic-6961/add slackbot install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.1.1 - 04/30/26**
+
+   - Feature: Add slack-setup make target to support sending Slack notifications from Slurm
+
 **3.1.0 - 04/22/26**
 
    - Refactor shared environment pipeline: archive current env with conda-pack before

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.1.2 - 05/04/26**
+**3.1.2 - 05/05/26**
 
    - Feature: Add setup-slack make target to support sending Slack notifications from Slurm
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 **3.1.1 - 04/30/26**
 
-   - Feature: Add slack-setup make target to support sending Slack notifications from Slurm
+   - Feature: Add setup-slack make target to support sending Slack notifications from Slurm
 
 **3.1.0 - 04/22/26**
 

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -48,6 +48,7 @@ help: # Curated help message
 	echo "manual-deploy-artifactory     Deploy package; only use if Jenkins deploy fails"; \
 	echo "model <command> [args]        Run model lineage tool (e.g., make model tree,"; \
 	echo "                              make model info v24.0)"; \
+	echo "setup-slack                   Configure Slack bot token in the active conda environment"; \
 	echo; \
 	echo "====================="; \
 	echo "Jenkins build targets"; \

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -48,7 +48,6 @@ help: # Curated help message
 	echo "manual-deploy-artifactory     Deploy package; only use if Jenkins deploy fails"; \
 	echo "model <command> [args]        Run model lineage tool (e.g., make model tree,"; \
 	echo "                              make model info v24.0)"; \
-	echo "setup-slack                   Configure Slack bot token in the active conda environment"; \
 	echo; \
 	echo "====================="; \
 	echo "Jenkins build targets"; \
@@ -127,7 +126,7 @@ install: # Install package and dependencies
 SLACK_BOT_CONFIG := /mnt/team/simulation_science/priv/engineering/config/slack_bot_config.sh
 
 .PHONY: setup-slack
-setup-slack: # Configure Slack bot token in the active conda environment
+setup-slack:
 	@if [ -f $(SLACK_BOT_CONFIG) ]; then \
 		activate_dir="$${CONDA_PREFIX}/etc/conda/activate.d"; \
 		deactivate_dir="$${CONDA_PREFIX}/etc/conda/deactivate.d"; \
@@ -137,7 +136,6 @@ setup-slack: # Configure Slack bot token in the active conda environment
 		echo "Slack bot token configured for this environment."; \
 	else \
 		echo "NOTE: Slack bot config not found at $(SLACK_BOT_CONFIG)."; \
-		echo "  Slack notifications will be disabled. See vivarium_cluster_tools docs for setup."; \
 	fi
 
 .PHONY: lint

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -120,6 +120,24 @@ install: # Install package and dependencies
 	pip install uv
 	uv pip install --upgrade pip setuptools 
 	uv pip install -e .[${ENV_REQS}] --extra-index-url ${IHME_PYPI}simple/ --index-strategy unsafe-best-match ${UV_FLAGS}
+	@$(MAKE) setup-slack
+
+# Path to shared Slack bot token on the team filesystem.
+SLACK_BOT_CONFIG := /mnt/team/simulation_science/priv/engineering/config/slack_bot_config.sh
+
+.PHONY: setup-slack
+setup-slack: # Configure Slack bot token in the active conda environment
+	@if [ -f $(SLACK_BOT_CONFIG) ]; then \
+		activate_dir="$${CONDA_PREFIX}/etc/conda/activate.d"; \
+		deactivate_dir="$${CONDA_PREFIX}/etc/conda/deactivate.d"; \
+		mkdir -p "$$activate_dir" "$$deactivate_dir"; \
+		cp $(SLACK_BOT_CONFIG) "$$activate_dir/psimulate_slack.sh"; \
+		echo 'unset PSIMULATE_SLACK_BOT_TOKEN' > "$$deactivate_dir/psimulate_slack.sh"; \
+		echo "Slack bot token configured for this environment."; \
+	else \
+		echo "NOTE: Slack bot config not found at $(SLACK_BOT_CONFIG)."; \
+		echo "  Slack notifications will be disabled. See vivarium_cluster_tools docs for setup."; \
+	fi
 
 .PHONY: lint
 lint: # Check for formatting errors


### PR DESCRIPTION
## Albrja/mic-6961/add slackbot install

### Add make target to install slack bot for conda environments
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6961

### Changes and notes
-adds make target to install slackbot

### Code reviewer
PR Review: Add slackbot install
Summary
This PR adds a setup-slack make target to base.mk that configures a Slack bot token in the active conda environment by copying a shared configuration script into conda's activate.d directory. The target is automatically invoked at the end of make install and gracefully degrades when the config file is not present. A corresponding CHANGELOG entry documents the addition.

Design
Missing CONDA_PREFIX guard — can write to system root — base.mk:128-129

$${CONDA_PREFIX} is used without checking if it's set. If someone runs make setup-slack (or make install) without an active conda env, the paths resolve to /etc/conda/activate.d and /etc/conda/deactivate.d, potentially writing to the system root or failing with a confusing permission error.

Suggestion: Add an early guard:


@if [ -z "$${CONDA_PREFIX}" ]; then \    echo "WARNING: No conda environment active; skipping Slack setup."; \elif [ -f $(SLACK_BOT_CONFIG) ]; then \    ...fi
Token file permissions not restricted — base.mk:131

cp inherits the default umask (typically 0022), making the token world-readable in the conda env. The source lives under a /priv/ path suggesting it's access-controlled, but that protection is lost on copy.

Suggestion: Add chmod 600 "$$activate_dir/psimulate_slack.sh" after the copy.

Copy vs. symlink — staleness on token rotation — base.mk:131

If the team rotates the bot token, every existing conda env retains a stale copy. A symlink (ln -sf) would always resolve to the latest token. Trade-off: requires the mount to be present at activation time (already true on Slurm nodes).

Suggestion: Consider using a symlink if token rotation is expected; otherwise document that a re-run of make setup-slack is needed after rotation.

Sub-make failure propagates to install — base.mk:122

If setup-slack fails (e.g., due to the unguarded CONDA_PREFIX issue), the entire make install fails. Since the intent is best-effort, either fix the guard (#1) or use @$(MAKE) setup-slack || true.

Maintainability
Hardcoded path with undocumented contract — base.mk:125

The comment says "shared Slack bot token" but doesn't document what the script exports. Only the deactivate script (unset PSIMULATE_SLACK_BOT_TOKEN) hints at the contract.

Suggestion: Expand the comment: # Must export PSIMULATE_SLACK_BOT_TOKEN. Managed by the engineering team.

Coupling: install unconditionally triggers Slack setup — base.mk:122

Developers on macOS/local machines will always see the "not found" note, which trains people to ignore make output. Consider making it opt-out via a variable (SETUP_SLACK ?= true) or suppressing the message when not on the cluster.

Destination filename psimulate_slack.sh encodes a specific downstream consumer — base.mk:131

The name couples this generic build-utils target to psimulate/vivarium_cluster_tools. Minor, but worth a comment explaining the naming choice.

DRY
No DRY violations found. The target is self-contained and follows existing patterns (recursive make, conditional guards) already used in the file.

Tests
No material test gap. This is a straightforward Makefile shell target in a repo without test infrastructure. The two branches (file exists / doesn't exist) will be exercised naturally by downstream CI.

Documentation
CHANGELOG target name is wrong — CHANGELOG.rst:3

Says "Add slack-setup make target" but the actual target is setup-slack. Should be fixed before merge.

Suggestion: - Feature: Add setup-slack make target to support sending Slack notifications from Slurm

help target doesn't list setup-slack — base.mk:42-68

The curated help output doesn't mention the new target. Users who encounter the "not found" message have no way to discover or understand it from make help.

Suggestion: Add under "Helper targets":


echo "setup-slack                   Configure Slack bot token in the active conda environment"; \
install target description unchanged — base.mk:120

Still says "Install package and dependencies" but now also configures Slack. The inline comment (which feeds into make list) should reflect this.

Functionality
Unset CONDA_PREFIX is a latent bug (also raised in Design #1)

This is the most impactful functional issue. In a non-conda environment (virtualenv, system Python, CI container), CONDA_PREFIX is empty, causing mkdir -p "/etc/conda/activate.d" — either a permission error or filesystem pollution on root-capable systems. Since make install unconditionally calls this, any non-conda usage of the Makefile hits this path.

Deactivate script only unsets one variable — base.mk:132

If slack_bot_config.sh ever exports additional variables, the deactivate script won't clean them up. This is an implicit contract between two independently-maintained files. Acceptable for now with a comment, but worth noting.

Minor Nits
The @ in @$(MAKE) setup-slack suppresses the make invocation echo but the sub-make's stdout is still visible. This is consistent with other targets in the file — no issue.
Overall
The core idea is sound — using conda activate hooks to inject environment-specific configuration is a well-established pattern. The main issues to address before merge are:

Must fix: CHANGELOG typo (#8) — factually incorrect
Should fix: CONDA_PREFIX guard (#1/#11) — latent bug that will surface in non-conda contexts
Should fix: File permissions (#2) — security hygiene for a token file on a shared cluster
Nice to have: Help target update (#9), comment improvements (#5)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

