### PR TITLE
Build conda env on slurm when we need scheduler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.1.1 - 04/29/26**
+
+   - Use NFS to build conda env on jobs that require slurm
+
 **3.1.0 - 04/22/26**
 
    - Refactor shared environment pipeline: archive current env with conda-pack before

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.1.1 - 04/29/26**
+**3.1.1 - 04/30/26**
 
    - Use NFS to build conda env on jobs that require slurm
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.1.1 - 04/30/26**
+**3.1.1 - 05/04/26**
 
    - Use NFS to build conda env on jobs that require slurm
 

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -27,16 +27,30 @@ def call(Map config = [:]){
   def scheduled_branches = config.scheduled_branches ?: [] 
   def stagger_scheduled_builds = config.stagger_scheduled_builds ?: false
   def test_types = config.test_types ?: ['all']
-  def task_node = config.requires_slurm ? 'slurm' : 'matrix-tasks'
+  def requires_slurm = config.requires_slurm ?: false
   def is_deployable = (config?.deployable == true)
   def skip_doc_build = (config?.skip_doc_build == true)
   def run_mypy = (config.run_mypy != null) ? config.run_mypy : true
+
+  // For requires_slurm: "weekly", the actual node/env decision is deferred
+  // until the Initialization stage where params.FORCE_SLOW_DAY is available.
+  // For true/false, we can resolve immediately.
+  def task_node
+  if (requires_slurm == "weekly") {
+    // Deferred — will be resolved in Initialization stage
+    task_node = null
+  } else {
+    task_node = requires_slurm ? 'slurm' : 'matrix-tasks'
+  }
+  conda_env_name_base = "${env.JOB_NAME}-${BUILD_NUMBER}"
+  // conda_env_dir is also deferred for "weekly" mode
+  conda_env_dir = (requires_slurm == true) ? "/mnt/team/simulation_science/priv/engineering/jenkins/envs" : "/svc-simsci/envs"
 
   echo "Configuration constants:"
   echo "  scheduled_branches: ${scheduled_branches}"
   echo "  stagger_scheduled_builds: ${stagger_scheduled_builds}"
   echo "  test_types: ${test_types}"
-  echo "  task_node: ${task_node}"
+  echo "  requires_slurm: ${requires_slurm}"
   echo "  is_deployable: ${is_deployable}"
   echo "  skip_doc_build: ${skip_doc_build}"
   echo "  run_mypy: ${run_mypy}"
@@ -53,9 +67,6 @@ def call(Map config = [:]){
   } else {
     cron_schedule = scheduled_branches.contains(BRANCH_NAME) ? "H H(20-23) * * *" : ''
   }
-
-  conda_env_name_base = "${env.JOB_NAME}-${BUILD_NUMBER}"
-  conda_env_dir = "/svc-simsci/envs"
 
   pipeline {
     environment {
@@ -150,6 +161,17 @@ def call(Map config = [:]){
             // Derive the deploy/docs version as the last entry in the list
             PYTHON_DEPLOY_VERSION = python_versions[-1]
             echo "Python deploy version (inferred): ${PYTHON_DEPLOY_VERSION}"
+
+            // Resolve deferred node/env for requires_slurm: "weekly"
+            if (requires_slurm == "weekly") {
+              def dayOfWeek = new Date().format('EEEE')
+              def is_slow_day = (dayOfWeek == 'Sunday')
+              echo "Weekly SLURM mode: dayOfWeek=${dayOfWeek}, is_slow_day=${is_slow_day}"
+              task_node = is_slow_day ? 'slurm' : 'matrix-tasks'
+              conda_env_dir = is_slow_day ? "/mnt/team/simulation_science/priv/engineering/jenkins/envs" : "/svc-simsci/envs"
+            }
+            echo "Resolved task_node: ${task_node}"
+            echo "Resolved conda_env_dir: ${conda_env_dir}"
           }
         }
       }

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -160,8 +160,6 @@ def call(Map config = [:]){
             // Derive the deploy/docs version as the last entry in the list
             PYTHON_DEPLOY_VERSION = python_versions[-1]
             echo "Python deploy version (inferred): ${PYTHON_DEPLOY_VERSION}"
-
-            echo "Resolved: task_node=${task_node}, conda_env_dir=${conda_env_dir}, use_slurm=${use_slurm}"
           }
         }
       }

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -32,19 +32,18 @@ def call(Map config = [:]){
   def skip_doc_build = (config?.skip_doc_build == true)
   def run_mypy = (config.run_mypy != null) ? config.run_mypy : true
 
-  // For requires_slurm: "weekly", the actual node/env decision is deferred
-  // until the Initialization stage where params.FORCE_SLOW_DAY is available.
-  // For true/false, we can resolve immediately.
-  def task_node
+  // Resolve task_node and conda_env_dir based on requires_slurm.
+  // "weekly" means only use SLURM + shared env on the slow-test day (Sunday).
+  def use_slurm
   if (requires_slurm == "weekly") {
-    // Deferred — will be resolved in Initialization stage
-    task_node = null
+    def dayOfWeek = new Date().format('EEEE')
+    use_slurm = (dayOfWeek == 'Sunday')
   } else {
-    task_node = requires_slurm ? 'slurm' : 'matrix-tasks'
+    use_slurm = requires_slurm ? true : false
   }
+  def task_node = use_slurm ? 'slurm' : 'matrix-tasks'
   conda_env_name_base = "${env.JOB_NAME}-${BUILD_NUMBER}"
-  // conda_env_dir is also deferred for "weekly" mode
-  conda_env_dir = (requires_slurm == true) ? "/mnt/team/simulation_science/priv/engineering/jenkins/envs" : "/svc-simsci/envs"
+  conda_env_dir = use_slurm ? "/mnt/team/simulation_science/priv/engineering/jenkins/envs" : "/svc-simsci/envs"
 
   echo "Configuration constants:"
   echo "  scheduled_branches: ${scheduled_branches}"
@@ -162,16 +161,7 @@ def call(Map config = [:]){
             PYTHON_DEPLOY_VERSION = python_versions[-1]
             echo "Python deploy version (inferred): ${PYTHON_DEPLOY_VERSION}"
 
-            // Resolve deferred node/env for requires_slurm: "weekly"
-            if (requires_slurm == "weekly") {
-              def dayOfWeek = new Date().format('EEEE')
-              def is_slow_day = (dayOfWeek == 'Sunday')
-              echo "Weekly SLURM mode: dayOfWeek=${dayOfWeek}, is_slow_day=${is_slow_day}"
-              task_node = is_slow_day ? 'slurm' : 'matrix-tasks'
-              conda_env_dir = is_slow_day ? "/mnt/team/simulation_science/priv/engineering/jenkins/envs" : "/svc-simsci/envs"
-            }
-            echo "Resolved task_node: ${task_node}"
-            echo "Resolved conda_env_dir: ${conda_env_dir}"
+            echo "Resolved: task_node=${task_node}, conda_env_dir=${conda_env_dir}, use_slurm=${use_slurm}"
           }
         }
       }


### PR DESCRIPTION
## Build conda env on slurm when we need scheduler
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7051

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
- added "weekly" option for requires_slurm
- only provision slurm node and NFS env when needed (say, not weekly) 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

