### PR TITLE
Add manual override to weekly slow test skip

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.2.0 - 05/05/26**
+**3.2.0 - 05/06/26**
 
    - Add manual override for "weekly" cluster tests.
    

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.2.0 - 05/05/26**
+
+   - Add manual override for "weekly" cluster tests.
+
 **3.1.1 - 05/04/26**
 
    - Use NFS to build conda env on jobs that require slurm

--- a/resources/makefiles/test.mk
+++ b/resources/makefiles/test.mk
@@ -1,11 +1,11 @@
 define test
 	export COVERAGE_FILE=./output/.coverage.$(1) && \
-	pytest -vvv $(if $(RUNSLOW),--runslow,) --cov --cov-report term --cov-report html:./output/htmlcov_$(1) tests/$(1)
+	pytest -vvv $(if $(RUNSLOW),--runslow,) $(if $(RUNWEEKLY),--runweekly,) --cov --cov-report term --cov-report html:./output/htmlcov_$(1) tests/$(1)
 endef
 
 test-all: # Run all tests
 	export COVERAGE_FILE=./output/.coverage && \
-	pytest -vvv $(if $(RUNSLOW),--runslow,) --cov --cov-report term --cov-report html:./output/htmlcov_tests tests/
+	pytest -vvv $(if $(RUNSLOW),--runslow,) $(if $(RUNWEEKLY),--runweekly,) --cov --cov-report term --cov-report html:./output/htmlcov_tests tests/
 
 test-e2e: # Run end-to-end tests
 	$(call test,e2e)

--- a/vars/build_stages.groovy
+++ b/vars/build_stages.groovy
@@ -25,6 +25,7 @@ def runDebugInfo(Map skipEval = [:]) {
         echo """Parameters:
         SKIP_DEPLOY: ${params.SKIP_DEPLOY}
         RUN_SLOW: ${params.RUN_SLOW}
+        RUN_WEEKLY: ${params.RUN_WEEKLY}
         SLACK_TO: ${params.SLACK_TO}
         DEBUG: ${params.DEBUG}
         FORCE_FULL_BUILD: ${params.FORCE_FULL_BUILD}"""
@@ -106,7 +107,7 @@ def runTests(List test_types) {
             def parallelTests = test_types.collectEntries {
                 ["${full_name(it)} Tests" : {
                     stage("Run ${full_name(it)} Tests - Python ${PYTHON_VERSION}") {
-                        sh "${ACTIVATE} && make ${it}${(env.IS_CRON.toBoolean() || params.RUN_SLOW) ? ' RUNSLOW=1' : ''}"
+                        sh "${ACTIVATE} && make ${it}${(env.IS_CRON.toBoolean() || params.RUN_SLOW) ? ' RUNSLOW=1' : ''}${(env.IS_CRON.toBoolean() || params.RUN_WEEKLY) ? ' RUNWEEKLY=1' : ''}"
                         // Map test target names to coverage directory names
                         // test-all -> htmlcov_tests, test-unit -> htmlcov_unit, etc.
                         def coverageDir = it == 'test-all' ? 'tests' : it.replace('test-', '')

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -32,18 +32,11 @@ def call(Map config = [:]){
   def skip_doc_build = (config?.skip_doc_build == true)
   def run_mypy = (config.run_mypy != null) ? config.run_mypy : true
 
-  // Resolve task_node and conda_env_dir based on requires_slurm.
-  // "weekly" means only use SLURM + shared env on the slow-test day (Sunday).
-  def use_slurm
-  if (requires_slurm == "weekly") {
-    def dayOfWeek = new Date().format('EEEE')
-    use_slurm = (dayOfWeek == 'Sunday')
-  } else {
-    use_slurm = requires_slurm ? true : false
-  }
-  def task_node = use_slurm ? 'slurm' : 'matrix-tasks'
+  // task_node and conda_env_dir are resolved in the Initialization stage
+  // after user parameters are available (needed for RUN_WEEKLY override).
+  def task_node
+  def conda_env_dir
   conda_env_name_base = "${env.JOB_NAME}-${BUILD_NUMBER}"
-  conda_env_dir = use_slurm ? "/mnt/team/simulation_science/priv/engineering/jenkins/envs" : "/svc-simsci/envs"
 
   echo "Configuration constants:"
   echo "  scheduled_branches: ${scheduled_branches}"
@@ -112,6 +105,11 @@ def call(Map config = [:]){
         description: "Whether to run slow tests as part of pytest suite."
       )
       booleanParam(
+        name: "RUN_WEEKLY",
+        defaultValue: false,
+        description: "Whether to run weekly tests (overrides slow test day check)."
+      )
+      booleanParam(
         name: "FORCE_FULL_BUILD",
         defaultValue: false,
         description: "Force a complete build regardless of change type (overrides doc-only and changelog-only skip logic)."
@@ -160,6 +158,20 @@ def call(Map config = [:]){
             // Derive the deploy/docs version as the last entry in the list
             PYTHON_DEPLOY_VERSION = python_versions[-1]
             echo "Python deploy version (inferred): ${PYTHON_DEPLOY_VERSION}"
+
+            // Resolve task_node and conda_env_dir based on requires_slurm.
+            // "weekly" means only use SLURM + shared env on the slow-test day
+            // (Sunday) or when the user explicitly requests weekly tests.
+            def use_slurm
+            if (requires_slurm == "weekly") {
+              def dayOfWeek = new Date().format('EEEE')
+              use_slurm = (dayOfWeek == 'Sunday' || params.RUN_WEEKLY)
+            } else {
+              use_slurm = requires_slurm ? true : false
+            }
+            task_node = use_slurm ? 'slurm' : 'matrix-tasks'
+            conda_env_dir = use_slurm ? "/mnt/team/simulation_science/priv/engineering/jenkins/envs" : "/svc-simsci/envs"
+            echo "Resolved task_node: ${task_node}, conda_env_dir: ${conda_env_dir}"
           }
         }
       }


### PR DESCRIPTION
## Add manual override to weekly slow test skip
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
feature/ CI
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7051

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
We want to be able to tell VTU to run the slowest weekly tests even if it is not the slow test day. I added a flag there to facilitate that, and am passing it through here.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

