### PR TITLE
Sbachmei/hotfix/find nested pytyped markers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.1.1 - 05/06/26**
+
+   - Search recursively for py.typed markers
+
 **3.1.0 - 04/22/26**
 
    - Refactor shared environment pipeline: archive current env with conda-pack before

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -194,8 +194,11 @@ clean: # Clean build artifacts and temporary files
 .PHONY: check
 check: # Run development checks
 	make lint
-# 	Run mypy if the py.typed file exists
-	@if [ -f "src/$(PACKAGE_NAME)/py.typed" ]; then \
+# 	Run mypy if any py.typed marker exists under src/
+# 	Use 'find' command rather than a hardcoded src/$(PACKAGE_NAME)/py.typed path so
+#	this works for both flat layouts (src/<pkg>/py.typed) and namespace layouts under
+#	monorepo (src/vivarium/<pkg>/py.typed).
+	@if find src -name py.typed 2>/dev/null | grep -q .; then \
 		echo; \
 		echo "Running mypy"; \
 		make mypy; \


### PR DESCRIPTION
## Find nested pytyped markers

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
We currently look for a hard-coded py.typed marker at specifically
"src/<pkg>/py.typed". But that doesn't work for monorepo b/c it's now
at "src/vivarium/<pkg>/py.typed". We could hardcode it, or I figure we 
could just used 'find' to support both.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

