### PR TITLE
fix invocation of run weekly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.2.1 - 05/07/26**
+
+   - Fix bug in manual override for "weekly" cluster tests.
+
 **3.2.0 - 05/06/26**
 
    - Add manual override for "weekly" cluster tests.

--- a/vars/build_stages.groovy
+++ b/vars/build_stages.groovy
@@ -94,7 +94,7 @@ def checkFormatting(Boolean run_mypy) {
     }
 }
 
-def runTests(List test_types) {
+def runTests(List test_types, boolean runWeekly) {
     stage("Run Tests - Python ${PYTHON_VERSION}") {
         script {
             def full_name = { test_type ->
@@ -107,7 +107,7 @@ def runTests(List test_types) {
             def parallelTests = test_types.collectEntries {
                 ["${full_name(it)} Tests" : {
                     stage("Run ${full_name(it)} Tests - Python ${PYTHON_VERSION}") {
-                        sh "${ACTIVATE} && make ${it}${(env.IS_CRON.toBoolean() || params.RUN_SLOW) ? ' RUNSLOW=1' : ''}${(env.IS_CRON.toBoolean() || params.RUN_WEEKLY) ? ' RUNWEEKLY=1' : ''}"
+                        sh "${ACTIVATE} && make ${it}${(env.IS_CRON.toBoolean() || params.RUN_SLOW) ? ' RUNSLOW=1' : ''}${runWeekly ? ' RUNWEEKLY=1' : ''}"
                         // Map test target names to coverage directory names
                         // test-all -> htmlcov_tests, test-unit -> htmlcov_unit, etc.
                         def coverageDir = it == 'test-all' ? 'tests' : it.replace('test-', '')

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -159,13 +159,17 @@ def call(Map config = [:]){
             PYTHON_DEPLOY_VERSION = python_versions[-1]
             echo "Python deploy version (inferred): ${PYTHON_DEPLOY_VERSION}"
 
+            // Determine whether to run weekly tests: on Sundays (for cron) or
+            // when the user explicitly requests them via the RUN_WEEKLY parameter.
+            def dayOfWeek = new Date().format('EEEE')
+            def run_weekly = params.RUN_WEEKLY || (env.IS_CRON.toBoolean() && dayOfWeek == 'Sunday')
+
             // Resolve task_node and conda_env_dir based on requires_slurm.
             // "weekly" means only use SLURM + shared env on the slow-test day
             // (Sunday) or when the user explicitly requests weekly tests.
             def use_slurm
             if (requires_slurm == "weekly") {
-              def dayOfWeek = new Date().format('EEEE')
-              use_slurm = (dayOfWeek == 'Sunday' || params.RUN_WEEKLY)
+              use_slurm = run_weekly
             } else {
               use_slurm = requires_slurm ? true : false
             }
@@ -240,7 +244,7 @@ def call(Map config = [:]){
                         buildStages.checkFormatting(run_mypy)
                         // Transform test type inputs to actual make test target names
                         tests = test_types.collect { "test-${it}" }
-                        buildStages.runTests(tests)
+                        buildStages.runTests(tests, run_weekly)
 
                         if (PYTHON_VERSION == PYTHON_DEPLOY_VERSION) {
                           if (!skip_doc_build) {

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -159,16 +159,18 @@ def call(Map config = [:]){
             PYTHON_DEPLOY_VERSION = python_versions[-1]
             echo "Python deploy version (inferred): ${PYTHON_DEPLOY_VERSION}"
 
-            // Determine whether to run weekly tests: on Sundays (for cron) or
-            // when the user explicitly requests them via the RUN_WEEKLY parameter.
-            def dayOfWeek = new Date().format('EEEE')
-            def run_weekly = params.RUN_WEEKLY || (env.IS_CRON.toBoolean() && dayOfWeek == 'Sunday')
-
-            // Resolve task_node and conda_env_dir based on requires_slurm.
-            // "weekly" means only use SLURM + shared env on the slow-test day
-            // (Sunday) or when the user explicitly requests weekly tests.
+            // Determine whether to run weekly tests. Weekly tests only apply
+            // when requires_slurm is "weekly" — triggered on Sundays (for cron)
+            // or when the user explicitly sets the RUN_WEEKLY parameter.
+            def run_weekly = false
             def use_slurm
+            // HACK MIC-7083: We are conflating "run weekly tests" with "use slurm weekly" here,
+            // even though you could conceivably have weekly tests that do not require slurm.
+            // This is to avoid having to propagate the runweekly flag to several repositories that
+            // do not currently inherit it from the VTU pytest plugin.
             if (requires_slurm == "weekly") {
+              def dayOfWeek = new Date().format('EEEE')
+              run_weekly = params.RUN_WEEKLY || (env.IS_CRON.toBoolean() && dayOfWeek == 'Sunday')
               use_slurm = run_weekly
             } else {
               use_slurm = requires_slurm ? true : false


### PR DESCRIPTION
## fix invocation of run weekly
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7080

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The last PR erroneously set runweekly tests if it was just a cron job, not filtering for the day.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

