### PR TITLE
make run_weekly available everywhere

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.2.2 - 05/07/26**
+
+   - Bugfix: Make "run_weekly" parameter available to all stages.
+
 **3.2.1 - 05/07/26**
 
    - Fix bug in manual override for "weekly" cluster tests.

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -32,10 +32,11 @@ def call(Map config = [:]){
   def skip_doc_build = (config?.skip_doc_build == true)
   def run_mypy = (config.run_mypy != null) ? config.run_mypy : true
 
-  // task_node and conda_env_dir are resolved in the Initialization stage
-  // after user parameters are available (needed for RUN_WEEKLY override).
+  // task_node, conda_env_dir, and run_weekly are resolved in the Initialization
+  // stage after user parameters are available (needed for RUN_WEEKLY override).
   def task_node
   def conda_env_dir
+  def run_weekly
   conda_env_name_base = "${env.JOB_NAME}-${BUILD_NUMBER}"
 
   echo "Configuration constants:"
@@ -162,7 +163,7 @@ def call(Map config = [:]){
             // Determine whether to run weekly tests. Weekly tests only apply
             // when requires_slurm is "weekly" — triggered on Sundays (for cron)
             // or when the user explicitly sets the RUN_WEEKLY parameter.
-            def run_weekly = false
+            run_weekly = false
             def use_slurm
             // HACK MIC-7083: We are conflating "run weekly tests" with "use slurm weekly" here,
             // even though you could conceivably have weekly tests that do not require slurm.


### PR DESCRIPTION
## make run_weekly available everywhere
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7080

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Let's try this again. Make run_weekly available to all pipeline stages.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

Confirmed this does work with:
(requires_slurm unset)
https://jenkins.simsci.ihme.washington.edu/job/github_repos/job/vivarium/job/pnast%252Ftesting%252Fjenkins/
(requires slurm == weekly, no override)
https://jenkins.simsci.ihme.washington.edu/job/github_repos/job/vivarium_cluster_tools/job/pnast%252Fhotfix%252Fmic-7051-weekly/12/
(requires slurm == weekly with override)
https://jenkins.simsci.ihme.washington.edu/job/github_repos/job/vivarium_cluster_tools/job/pnast%252Fhotfix%252Fmic-7051-weekly/13/