### PR TITLE
Sbachmei/hotfix/add support for prefixes in tag validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
    - Search recursively for py.typed markers
    - Make the artifactory extra-index URL configurable via Make variable
    - Add 'env_reqs' parameter to reusable_pipeline.groovy for specifying CI build install extras
+   - Add tag prefix support during tag validation
 
 **3.2.2 - 05/07/26**
 

--- a/resources/scripts/validate_tag_version.sh
+++ b/resources/scripts/validate_tag_version.sh
@@ -48,6 +48,10 @@ if [ ! -f "$CHANGELOG_PATH" ]; then
     exit 1
 fi
 
+# Optional tag prefix for monorepo libs whose tags look like
+# "vivarium-<lib>-vX.Y.Z" rather than "vX.Y.Z". Empty for standalone repos.
+TAG_PREFIX="${TAG_PREFIX:-}"
+
 # Determine the tag to validate
 RELEASE_TAG="${GITHUB_REF_NAME:-}"
 if [ -z "$RELEASE_TAG" ]; then
@@ -55,10 +59,11 @@ if [ -z "$RELEASE_TAG" ]; then
     exit 1
 fi
 
-# Extract version from tag (remove 'v' prefix if present)
-RELEASE_VERSION=$(echo "$RELEASE_TAG" | sed 's/^v//')
+# Extract version from tag: strip optional TAG_PREFIX, then optional 'v'.
+RELEASE_VERSION="${RELEASE_TAG#$TAG_PREFIX}"
+RELEASE_VERSION="${RELEASE_VERSION#v}"
 if ! is_strict_semver "$RELEASE_VERSION"; then
-    echo "ERROR: Tag '$RELEASE_TAG' must be strict semantic version format vX.Y.Z or X.Y.Z"
+    echo "ERROR: Tag '$RELEASE_TAG' must be strict semantic version format ${TAG_PREFIX}vX.Y.Z or ${TAG_PREFIX}X.Y.Z"
     exit 1
 fi
 
@@ -95,8 +100,9 @@ if [ "$RELEASE_VERSION" != "$CHANGELOG_VERSION" ]; then
 fi
 
 # Validate one-step bump against the previous released git tag (not changelog order).
+# When TAG_PREFIX is set, only tags matching the prefix participate.
 PREVIOUS_RELEASE_VERSION=$( (
-    git tag --list 2>/dev/null | sed 's/^v//'
+    git tag --list "${TAG_PREFIX}*" 2>/dev/null | sed "s|^${TAG_PREFIX}||" | sed 's/^v//'
     echo "$RELEASE_VERSION"
 ) | while IFS= read -r version; do
     if is_strict_semver "$version"; then


### PR DESCRIPTION
## Add support for prefixes in tag validation

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Trying to release the new comp package failed after relying on 
`make validate-tag` b/c that command didn't know about the
package-specific prefixes (e.g. profiling-v0.1.4, not just v0.1.4).
This adds that support.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

