### PR TITLE
Fix JsonSlurper usage being unserializable

### DIFF
--- a/vars/get_python_versions.groovy
+++ b/vars/get_python_versions.groovy
@@ -10,11 +10,20 @@
 //                   python_versions.json is picked up instead of the monorepo root.
 import groovy.json.JsonSlurper
 
+// JsonSlurper is not serializable, so it must not be alive on the continuous-passing
+// style (CPS) evaluation stack across a suspending step (e.g. readFile). Construct and 
+// consume it inside an @NonCPS helper to guarantee it never participates in program persistence.
+@NonCPS
+def parseJson(String text) {
+    return new JsonSlurper().parseText(text)
+s}
+
 def call(workspace, git_url, String subdir = '') {
     def repo_name = git_url.tokenize("/")[-1].tokenize(".")[0]
     def filename = subdir ? "${workspace}/${subdir}/python_versions.json" : "${workspace}/python_versions.json"
     if (!fileExists(filename)) {
         error("python_versions.json not found at ${filename} in repository ${repo_name}")
     }
-    return new JsonSlurper().parseText(readFile(filename))
+    def text = readFile(filename)
+    return parseJson(text)
 }


### PR DESCRIPTION
## Fix JsonSlurper usage being unserializable

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Everything Jenkins does needs to be serializable so it can survive
controller restarts. I guess the `JsonSlurper()` is not and this
somehow fixes that. I'm not sure why it hasn't been failing for the
POC, but claude seems to think that's not a big concern and
"latent CPS bugs are notoriously roll-of-the-dice." 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

