### PR TITLE
Install in editable_mode=compat to not break py.typed marker discovery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@
      Actions runners outside the IHME network)
    - Guard ``make deploy-package-artifactory`` against an empty ``IHME_PYPI``
    - Search recursively for ``py.typed`` markers so monorepo packages are detected
+   - ``make install``: install in editable_mode=compat to not break py.typed marker discovery
 
 **3.2.2 - 05/07/26**
 

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -124,7 +124,15 @@ install: UV_FLAGS?=
 install: # Install package and dependencies
 	pip install uv
 	uv pip install --upgrade pip setuptools ${UV_FLAGS}
-	uv pip install -e .[${ENV_REQS}] ${EXTRA_INDEX_FLAGS} ${UV_FLAGS}
+	# NOTE: editable_mode=compat: produces a classic .pth-based editable install
+	#   (sys.path entry pointing at src/) instead of the PEP 660 default
+	#   (sys.meta_path finder). The PEP 660 mode breaks mypy's discovery of
+	#   sibling-namespace packages in monorepo dev setups - mypy's static
+	#   path-walk doesn't invoke meta_path finders, so it sees an empty
+	#   site-packages/<namespace>/ directory and reports the lib as untyped
+	#   even when py.typed is shipped in source. Classic mode produces real
+	#   sys.path entries that mypy traverses normally.
+	uv pip install -e .[${ENV_REQS}] --config-settings editable_mode=compat ${EXTRA_INDEX_FLAGS} ${UV_FLAGS}
 	@$(MAKE) setup-slack
 
 # Path to shared Slack bot token on the team filesystem.


### PR DESCRIPTION
## Fix py.typed marker discrovery

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This was a latent bug specific to having multiple libs _from the same repo_
installed editably. The default PEP660 makes it such that the 
`make install` (which does a `uv pip install -e ...` can't find the
py.typed markers in the wheel. 

Apparently PEP 660 doesn't allow for static analyzers to follow `sys.meta_path`
by default. I don't really understand all this nonsense, but Claude assures me that:

> Why PEP 660 is the default: the ecosystem (pip, build tools, IDEs, test runners) was modernized around it, and the wheel-parity benefits are real for the 99% of projects that don't have a monorepo + sibling-namespace + strict-mypy interaction. We're the awkward edge case — a vivarium.engine import that must type-check against an editably-installed vivarium.artifact is a specific cross-distribution pattern that PEP 660's meta_path approach handles correctly at runtime but not at static-analysis time.Why PEP 660 is the default: the ecosystem (pip, build tools, IDEs, test runners) was modernized around it, and the wheel-parity benefits are real for the 99% of projects that don't have a monorepo + sibling-namespace + strict-mypy interaction. We're the awkward edge case — a vivarium.engine import that must type-check against an editably-installed vivarium.artifact is a specific cross-distribution pattern that PEP 660's meta_path approach handles correctly at runtime but not at static-analysis time.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

