### PR TITLE
Scope uv pip install editable_mode=compat to local package

### DIFF
--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -8,6 +8,12 @@ LOCATIONS=src tests
 # Unless overridden, build conda environment using the package name.
 SAFE_NAME = $(shell python -c "from pkg_resources import safe_name; print(safe_name(\"$(PACKAGE_NAME)\"))")
 
+# DIST_NAME is the PyPI distribution name read from pyproject.toml's `[project].name`
+# (e.g. "vivarium-cluster-tools" for libs/cluster-tools/).
+DIST_NAME ?= $(shell python -c "import tomllib; data=tomllib.load(open('pyproject.toml','rb')); print(data.get('project',{}).get('name',''))" 2>/dev/null)
+# Fall back to PACKAGE_NAME for legacy repos that don't declare `[project]` in a pyproject.toml.
+DIST_NAME := $(if $(DIST_NAME),$(DIST_NAME),$(PACKAGE_NAME))
+
 PACKAGE_VERSION = $(shell grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.rst | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 
 # Use this URL to pull IHME Python packages and deploy this package to PyPi.
@@ -132,7 +138,12 @@ install: # Install package and dependencies
 	#   site-packages/<namespace>/ directory and reports the lib as untyped
 	#   even when py.typed is shipped in source. Classic mode produces real
 	#   sys.path entries that mypy traverses normally.
-	uv pip install -e .[${ENV_REQS}] --config-settings editable_mode=compat ${EXTRA_INDEX_FLAGS} ${UV_FLAGS}
+	#   Scoped to the local package via --config-settings-package (not the
+	#   global --config-settings). The setting is a setuptools-only concept;
+	#   passing it globally leaks it to transitive sdist builds whose backends
+	#   don't recognize it (numpy 1.x's meson-python errors on it with
+	#   "Unknown option editable_mode").
+	uv pip install -e .[${ENV_REQS}] --config-settings-package ${DIST_NAME}=editable_mode=compat ${EXTRA_INDEX_FLAGS} ${UV_FLAGS}
 	@$(MAKE) setup-slack
 
 # Path to shared Slack bot token on the team filesystem.


### PR DESCRIPTION
## Scope uv pip install editable_mode=compat to local package

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
When trying to build the migrated vivarium-cluster-tools, it was erroring
because it vct requires numpy<=2.0.0. However, the compat mode install
we hotifxed applies it globally, including transitifive dependencies and that
was somehow breaking things.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

