### PR TITLE
Sbachmei/mic 7187/in tree siblings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,216 +1,221 @@
-**x.x.x - tbd**
+**3.3.0 - tbd**
 
-   - Add monorepo support: top-level ``monorepo()`` step that provisions per-package
-     Jenkins Multibranch Pipelines, ``withWorkingDirectory`` routing of build stages
-     into ``libs/<pkg>/``, and ``get_package_subdir()`` for resolving the package
-     subdir from JOB_NAME
-   - Add ``TAG_PREFIX`` support across ``make tag-version``, ``make validate-tag``,
-     and ``validate_tag_version.sh`` so monorepo libs can use prefixed tags
-     (e.g. ``vivarium-core-v1.2.3``)
-   - Add ``env_reqs`` parameter to ``reusable_pipeline.groovy`` for selecting the
-     pyproject.toml extras installed during CI
-   - Make the artifactory extra-index URL configurable via the ``IHME_PYPI`` Make
-     variable; setting it empty disables the extra-index entirely (for GitHub
-     Actions runners outside the IHME network)
-   - Guard ``make deploy-package-artifactory`` against an empty ``IHME_PYPI``
-   - Search recursively for ``py.typed`` markers so monorepo packages are detected
-   - ``make install``: install in editable_mode=compat to not break py.typed marker discovery
-   - Add GitHUb App authenticaion support for deployable packages
+Support for monorepo structure:
+- Add monorepo support: top-level ``monorepo()`` step that provisions per-package
+  Jenkins Multibranch Pipelines, ``withWorkingDirectory`` routing of build stages
+  into ``libs/<pkg>/``, and ``get_package_subdir()`` for resolving the package
+  subdir from JOB_NAME
+- Add ``TAG_PREFIX`` support across ``make tag-version``, ``make validate-tag``,
+  and ``validate_tag_version.sh`` so monorepo libs can use prefixed tags
+  (e.g. ``vivarium-core-v1.2.3``)
+- Add ``env_reqs`` parameter to ``reusable_pipeline.groovy`` for selecting the
+  pyproject.toml extras installed during CI
+- Make the artifactory extra-index URL configurable via the ``IHME_PYPI`` Make
+  variable; setting it empty disables the extra-index entirely (for GitHub
+  Actions runners outside the IHME network)
+- Guard ``make deploy-package-artifactory`` against an empty ``IHME_PYPI``
+- Search recursively for ``py.typed`` markers so monorepo packages are detected
+- ``make install``: install in editable_mode=compat to not break py.typed marker discovery
+- Install a monorepo package's in-tree sibling dependencies from source at their
+  pending CHANGELOG versions (allows single-PR updates to multiple packages)
+
+Miscellaneous:
+- Add GitHUb App authenticaion support for deployable packages
 
 **3.2.2 - 05/07/26**
 
-   - Bugfix: Make "run_weekly" parameter available to all stages.
+- Bugfix: Make "run_weekly" parameter available to all stages.
 
 **3.2.1 - 05/07/26**
 
-   - Fix bug in manual override for "weekly" cluster tests.
+- Fix bug in manual override for "weekly" cluster tests.
 
 **3.2.0 - 05/06/26**
 
-   - Add manual override for "weekly" cluster tests.
+- Add manual override for "weekly" cluster tests.
    
 **3.1.2 - 05/05/26**
 
-   - Feature: Add setup-slack make target to support sending Slack notifications from Slurm
+- Feature: Add setup-slack make target to support sending Slack notifications from Slurm
 
 **3.1.1 - 05/04/26**
 
-   - Use NFS to build conda env on jobs that require slurm
+- Use NFS to build conda env on jobs that require slurm
 
 **3.1.0 - 04/22/26**
 
-   - Refactor shared environment pipeline: archive current env with conda-pack before
-     rebuild, rebuild in-place, diff packages, and notify Slack with package diffs.
-     Add archive retention cleanup (default 7 days).
+- Refactor shared environment pipeline: archive current env with conda-pack before
+  rebuild, rebuild in-place, diff packages, and notify Slack with package diffs.
+  Add archive retention cleanup (default 7 days).
      
 **3.0.4 - 04/17/26**
 
-   - Bugfix: Only clean up /svc-simsci/envs on the node that actually has it
-   - Feature: Catch errors so that we run through all stages rather than aborting on first failure
+- Bugfix: Only clean up /svc-simsci/envs on the node that actually has it
+- Feature: Catch errors so that we run through all stages rather than aborting on first failure
 
 **3.0.3 - 04/16/26**
 
-   - Use --no-cache when running pip install dryrun for getting vbu version
+- Use --no-cache when running pip install dryrun for getting vbu version
 
 **3.0.2 - 04/15/26**
 
-   - Change the vbu-version bootstrapping to use Jenkins coordinator node
+- Change the vbu-version bootstrapping to use Jenkins coordinator node
 
 **3.0.1 - 04/14/26**
 
-   - Move environment building back to /svc-simsci scratch spaces on jenkins nodes.
+- Move environment building back to /svc-simsci scratch spaces on jenkins nodes.
 
 **3.0.0 - 03/30/26**
 
-   - Remove installDependencies stage and upstream_repos config option
+- Remove installDependencies stage and upstream_repos config option
 
 **2.3.8 - 03/16/26**
 
-   - Create a make target for version validation
+- Create a make target for version validation
 
 **2.3.7 - 03/12/26**
 
-   - Validate github repo version prior to deploying
+- Validate github repo version prior to deploying
 
 **2.3.6 - 03/10/26**
 
-    - Bugfix: Fix list parsing and version comparison for python version inference
+- Bugfix: Fix list parsing and version comparison for python version inference
 
 **2.3.5 - 03/09/26**
 
-   - Feature: Infer python version for builds and deployment from downstream repos
+- Feature: Infer python version for builds and deployment from downstream repos
 
 **2.3.4 - 03/02/26**
 
-  - Bugfix: Fix cleanup of environments from Jenkins builds
+- Bugfix: Fix cleanup of environments from Jenkins builds
 
 **2.3.3 - 02/27/26**
 
-  - Drop support for python 3.13, support 3.12
+- Drop support for python 3.13, support 3.12
 
 **2.3.2 - 02/25/26**
 
-  - Slack CI channel for failing builds for all scheduled branches
+- Slack CI channel for failing builds for all scheduled branches
 
 **2.3.1 - 02/23/26**
 
-  - Increase cleanup job timeout
+- Increase cleanup job timeout
 
 **2.3.0 - 02/18/26**
 
-  - Feature: Support python 3.13
-  - Command: `make build-env` now defaults to python 3.13
+- Feature: Support python 3.13
+- Command: `make build-env` now defaults to python 3.13
 
 **2.2.4 - 02/10/26**
 
-  - Bugfix: fix timeout env variable in jenkinsfile
-  - Bugfix: fix the cleanup depth for the shared directory
-  - Bugfix: fix doc-only / changelog-only skipping behavior
+- Bugfix: fix timeout env variable in jenkinsfile
+- Bugfix: fix the cleanup depth for the shared directory
+- Bugfix: fix doc-only / changelog-only skipping behavior
 
 **2.2.3 - 02/09/26**
 
-  - Increase the cleanup Jenkins job timeout to 120 minutes
-  - Message the slack channel when the cleanup job is aborted
+- Increase the cleanup Jenkins job timeout to 120 minutes
+- Message the slack channel when the cleanup job is aborted
 
 **2.2.2 - 01/27/26**
 
-  - Stop skipping any builds (temporary)
+- Stop skipping any builds (temporary)
 
 **2.2.1 - 01/27/26**
 
-  - Stop skipping builds if CHANGELOG-only commit (temporary)
+- Stop skipping builds if CHANGELOG-only commit (temporary)
 
 **2.2.0 - 01/26/26**
 
-  - Feature: Add shared model environments nightly build
+- Feature: Add shared model environments nightly build
 
 **2.1.2 - 01/15/26**
 
-  - Bugfix: use PST timezone for CHANGELOG date validation
+- Bugfix: use PST timezone for CHANGELOG date validation
 
 **2.1.1 - 01/06/26**
 
-  - Fail deployment if CHANGELOG date does not match current date
-  - Add CHANGELOG date validation for Jenkins pipeline
+- Fail deployment if CHANGELOG date does not match current date
+- Add CHANGELOG date validation for Jenkins pipeline
 
 **2.1.0 - 12/16/2025**
 
-  - Feature: Add model lineage analysis utility
+- Feature: Add model lineage analysis utility
 
 **2.0.13 - 11/21/2025**
 
-  - Bugfix: stop skipping scheduled builds if the last commit was CHANGELOG-only
+- Bugfix: stop skipping scheduled builds if the last commit was CHANGELOG-only
 
 **2.0.12 - 10/22/2025**
 
-  - Skip Jenkins builds for CHANGELOG-only commits
-  - Skip doc checks if there is no docs/ directory
+- Skip Jenkins builds for CHANGELOG-only commits
+- Skip doc checks if there is no docs/ directory
 
 **2.0.11 - 10/7/2025**
 
-  - Stop cacheing secondary uv pip install
+- Stop cacheing secondary uv pip install
 
 **2.0.10 - 10/2/2025**
 
-  - Bugfix: Remove Make sources
+- Bugfix: Remove Make sources
 
 **2.0.9 - 10/1/2025**
 
-  - Bugfix: Change name of doc build directory
+- Bugfix: Change name of doc build directory
 
 **2.0.8 - 9/24/2025**
 
-  - Revert disabling dependent branch installs (v2.0.7)
-  - Stop explicit folder deletion in cleanup
+- Revert disabling dependent branch installs (v2.0.7)
+- Stop explicit folder deletion in cleanup
 
 **2.0.7 - 9/23/2025**
 
-  - Disable dependent branch installs
+- Disable dependent branch installs
 
 **2.0.6 - 8/20/2025**
 
-  - Validate arguments passed to reusable_pipeline.groovy
+- Validate arguments passed to reusable_pipeline.groovy
 
 **2.0.5 - 8/8/2025**
 
-  - Create pipeline to clean up Jenkins build directories
+- Create pipeline to clean up Jenkins build directories
 
 **2.0.4 - 8/6/2025**
 
-  - Revert v2.0.3
+- Revert v2.0.3
 
 **2.0.3 - 8/5/2025**
 
-  - Use Jenkins node /tmp/ dir (reversion from v2.0.2) until permissions get resolved
+- Use Jenkins node /tmp/ dir (reversion from v2.0.2) until permissions get resolved
 
 **2.0.2 - 8/4/2025**
 
-  - Create all Jenkins build envs in shared team folder
+- Create all Jenkins build envs in shared team folder
 
 **2.0.1 - 7/25/2025**
 
-  - Bugfix: fix broken doc stages in Jenkins pipeline
+- Bugfix: fix broken doc stages in Jenkins pipeline
 
 **2.0.0 - 7/24/2025**
 
-  - Clean up and better document Make files
+- Clean up and better document Make files
 
 **1.1.2 - 7/16/2025**
 
-  - Bugfix: typo in extra-index-url
+- Bugfix: typo in extra-index-url
 
 **1.1.1 - 7/16/2025**
 
-  - Bugfix: fix broken pip install --dry-run call in get_vbu_version.py
+- Bugfix: fix broken pip install --dry-run call in get_vbu_version.py
 
 **1.1.0 - 7/15/2025**
 
-  - Allow for pinning in other repos
+- Allow for pinning in other repos
 
 **1.0.0 - 7/8/2025**
 
-  - Initial major release
+- Initial major release
 
 **0.1.0 - 7/8/2025**
 
-  - Initial rc release
+- Initial rc release

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,11 +16,14 @@ Support for monorepo structure:
 - Guard ``make deploy-package-artifactory`` against an empty ``IHME_PYPI``
 - Search recursively for ``py.typed`` markers so monorepo packages are detected
 - ``make install``: install in editable_mode=compat to not break py.typed marker discovery
-- Install a monorepo package's in-tree sibling dependencies from source at their
-  pending CHANGELOG versions (allows single-PR updates to multiple packages)
+- ``make install IN_TREE_SIBLINGS=1``: install a monorepo package's in-tree sibling
+  dependencies from source at their pending CHANGELOG versions, so a single PR can
+  update interdependent packages without an intermediate release. Backed by a new
+  ``vivarium_build_utils.dependencies`` graph helper/CLI (also used to order releases
+  dependencies-first); off by default and a no-op outside a ``libs/<pkg>/`` layout
 
 Miscellaneous:
-- Add GitHUb App authenticaion support for deployable packages
+- Add GitHub App authentication support for deployable packages
 
 **3.2.2 - 05/07/26**
 

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,26 @@ standalone repo would, with one new argument::
 install`` pulls in. Omit it (or leave empty) on standalone repos to keep
 base.mk's default of ``dev``.
 
+In-tree sibling dependencies
+----------------------------
+
+By default ``make install`` resolves a package's dependencies - including
+sibling packages in the same monorepo - from the package index. Pass
+``IN_TREE_SIBLINGS=1`` to instead install in-tree siblings from source first, at
+the *pending* version in each sibling's ``CHANGELOG.rst``::
+
+  make install ENV_REQS=ci_github IN_TREE_SIBLINGS=1
+
+This lets a single PR update interdependent packages without an intermediate
+release: a dependent pinned as ``vivarium-engine>=<new>`` is satisfied by the
+in-tree source - the pending version is reported through setuptools_scm's
+pretend-version mechanism - rather than requiring ``<new>`` to be published
+first. Which siblings get installed depends on ``ENV_REQS`` (the extras being
+installed). It is a no-op when unset and outside a ``libs/<pkg>/`` layout, so it
+is safe to leave off for standalone repos. Set it for the test/gating CI build;
+omit it for the release build so published version pins are still validated
+against the real index.
+
 Tag prefix
 ----------
 

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -132,15 +132,24 @@ install: IN_TREE_SIBLINGS?=
 install: # Install package and dependencies
 	pip install uv
 	uv pip install --upgrade pip setuptools ${UV_FLAGS}
+#	Install in-tree sibling deps editable BEFORE the package itself. The query
+#	output is captured first (not piped) so a failure in it - bad target, broken
+#	pyproject.toml - aborts the build via `|| exit 1` instead of being swallowed
+#	by the pipeline and silently installing nothing. We iterate with a here-string (<<<)
+#	so the loop runs in this shell, making `exit 1` unambiguous. For each sibling,
+#	`env $${ver:+VAR=ver}` sets the setuptools_scm pretend-version env var only when
+#	a CHANGELOG version was found (so the editable sibling reports its pending
+#	version and satisfies a `>=NEW` pin); with no version, setuptools_scm derives it
+#	from git. DIST_NAME is the authoritative package key (matches the query's index).
 	@if [ -n "${IN_TREE_SIBLINGS}" ]; then \
 		echo "Resolving in-tree sibling dependencies from source (ENV_REQS=${ENV_REQS})"; \
-		python -m vivarium_build_utils.dependencies siblings ${PACKAGE_NAME} $(foreach e,${ENV_REQS},--extra $(e)) \
-		| while IFS="$$(printf '\t')" read -r sib_dir sib_envvar sib_version; do \
+		siblings="$$(python -m vivarium_build_utils.dependencies siblings ${DIST_NAME} $(foreach e,${ENV_REQS},--extra $(e)))" || exit 1; \
+		while IFS="$$(printf '\t')" read -r sib_dir sib_envvar sib_version; do \
 			[ -z "$$sib_dir" ] && continue; \
 			echo "  in-tree sibling: $$sib_dir (pretend version $${sib_version:-<scm>})"; \
 			env $${sib_version:+$$sib_envvar=$$sib_version} \
 				uv pip install -e "$$sib_dir" --no-deps ${UV_FLAGS} || exit 1; \
-		done; \
+		done <<< "$$siblings"; \
 	fi
 	# NOTE: editable_mode=compat: produces a classic .pth-based editable install
 	#   (sys.path entry pointing at src/) instead of the PEP 660 default

--- a/resources/makefiles/base.mk
+++ b/resources/makefiles/base.mk
@@ -128,9 +128,20 @@ create-env: # Create a new conda environment
 .PHONY: install
 install: ENV_REQS?=dev
 install: UV_FLAGS?=
+install: IN_TREE_SIBLINGS?=
 install: # Install package and dependencies
 	pip install uv
 	uv pip install --upgrade pip setuptools ${UV_FLAGS}
+	@if [ -n "${IN_TREE_SIBLINGS}" ]; then \
+		echo "Resolving in-tree sibling dependencies from source (ENV_REQS=${ENV_REQS})"; \
+		python -m vivarium_build_utils.dependencies siblings ${PACKAGE_NAME} $(foreach e,${ENV_REQS},--extra $(e)) \
+		| while IFS="$$(printf '\t')" read -r sib_dir sib_envvar sib_version; do \
+			[ -z "$$sib_dir" ] && continue; \
+			echo "  in-tree sibling: $$sib_dir (pretend version $${sib_version:-<scm>})"; \
+			env $${sib_version:+$$sib_envvar=$$sib_version} \
+				uv pip install -e "$$sib_dir" --no-deps ${UV_FLAGS} || exit 1; \
+		done; \
+	fi
 	# NOTE: editable_mode=compat: produces a classic .pth-based editable install
 	#   (sys.path entry pointing at src/) instead of the PEP 660 default
 	#   (sys.meta_path finder). The PEP 660 mode breaks mypy's discovery of

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,11 @@ if __name__ == "__main__":
         ],
         package_dir={"": "src"},
         packages=find_packages(where="src"),
+        install_requires=[
+            # tomllib is stdlib on 3.11+; tomli backfills it on 3.10 so the
+            # monorepo dependency-graph utility can parse pyproject.toml there.
+            "tomli; python_version < '3.11'",
+        ],
         package_data={
             "vivarium_build_utils": [
                 "resources/**/*",

--- a/src/vivarium_build_utils/dependencies.py
+++ b/src/vivarium_build_utils/dependencies.py
@@ -38,7 +38,11 @@ except ModuleNotFoundError:  # Python < 3.11
 _CANONICALIZE = re.compile(r"[-_.]+")
 # Distribution name (optionally with [extras]) at the start of a requirement string.
 _REQUIREMENT = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:\[([^\]]*)\])?")
-_VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+# CHANGELOG.rst entries open with a header like ``**X.Y.Z - MM/DD/YY**``. Anchor on
+# that shape so a date or a version mentioned in prose isn't mistaken for the
+# release version. This mirrors the intent of base.mk's PACKAGE_VERSION grep,
+# anchored on the header rather than matching the first triple anywhere.
+_CHANGELOG_HEADER = re.compile(r"^\*\*\s*(\d+\.\d+\.\d+)")
 
 
 def canonical_name(name: str) -> str:
@@ -89,14 +93,24 @@ class Lib:
         return self.directory.name
 
     def changelog_version(self) -> str | None:
-        """Return the pending version from the first CHANGELOG.rst line, if any."""
+        """Return the first version found in CHANGELOG.rst, if any.
+
+        Reads the version from the leading ``**X.Y.Z - ...**`` header. Intentionally
+        mirrors base.mk's ``PACKAGE_VERSION`` rule (kept a separate copy because
+        base.mk must derive the version before this package is installed).
+
+        Returns
+        -------
+        The ``X.Y.Z`` from the first CHANGELOG header line, or ``None`` when there
+        is no CHANGELOG or no header carrying a version.
+        """
         changelog = self.directory / "CHANGELOG.rst"
         if not changelog.exists():
             return None
         for line in changelog.read_text(encoding="utf-8").splitlines():
-            match = _VERSION.search(line)
+            match = _CHANGELOG_HEADER.match(line)
             if match:
-                return match.group(0)
+                return match.group(1)
         return None
 
 
@@ -147,12 +161,31 @@ def load_libs(libs_root: Path | None = None) -> dict[str, Lib]:
     return libs
 
 
-def _resolve_dir_name(libs: dict[str, Lib], target: str) -> Lib:
-    """Resolve a target given either its canonical dist name or its libs/ dir name."""
+def _resolve_dir_name(
+    libs: dict[str, Lib], target: str, by_dir: dict[str, Lib] | None = None
+) -> Lib:
+    """Resolve a target given its canonical dist name or its libs/ dir name.
+
+    Parameters
+    ----------
+    libs
+        The in-tree package index from :func:`load_libs`.
+    target
+        A canonical distribution name or a libs/ directory name.
+    by_dir
+        Optional prebuilt dir-name index. Pass it when resolving many targets so
+        the map is not rebuilt on every call.
+
+    Raises
+    ------
+    KeyError
+        If no in-tree package matches ``target``.
+    """
     canonical = canonical_name(target)
     if canonical in libs:
         return libs[canonical]
-    by_dir = {lib.dir_name: lib for lib in libs.values()}
+    if by_dir is None:
+        by_dir = {lib.dir_name: lib for lib in libs.values()}
     if target in by_dir:
         return by_dir[target]
     raise KeyError(f"No in-tree package matching {target!r}")
@@ -167,12 +200,12 @@ def _direct_in_tree_deps(lib: Lib, libs: dict[str, Lib], extras: tuple[str, ...]
     not returned.
     """
     found: set[str] = set()
-    queue: list[tuple[str, list[str]]] = list(lib.runtime)
+    stack: list[tuple[str, list[str]]] = list(lib.runtime)
     for extra in extras:
-        queue.extend(lib.extras.get(extra, []))
+        stack.extend(lib.extras.get(extra, []))
     seen_self_extras: set[str] = set()
-    while queue:
-        base, dep_extras = queue.pop()
+    while stack:
+        base, dep_extras = stack.pop()
         if not base:
             continue
         if base == lib.name:
@@ -180,7 +213,7 @@ def _direct_in_tree_deps(lib: Lib, libs: dict[str, Lib], extras: tuple[str, ...]
             for extra in dep_extras:
                 if extra not in seen_self_extras:
                     seen_self_extras.add(extra)
-                    queue.extend(lib.extras.get(extra, []))
+                    stack.extend(lib.extras.get(extra, []))
             continue
         if base in libs:
             found.add(base)
@@ -197,6 +230,21 @@ def reachable_siblings(
     that is all an installed dependency pulls in. The target itself is excluded.
     Order is unspecified - callers install siblings with ``--no-deps``, so the
     set is what matters and the result is immune to dependency cycles.
+
+    Parameters
+    ----------
+    target
+        The package to resolve, as a canonical dist name or libs/ dir name.
+    libs
+        The in-tree package index from :func:`load_libs`.
+    extras
+        Optional-dependency extras the install activates for ``target``; followed
+        only at the root (see the module's runtime-vs-install-time distinction).
+
+    Returns
+    -------
+    The in-tree siblings ``target`` transitively depends on, sorted by name,
+    excluding ``target`` itself.
     """
     root = _resolve_dir_name(libs, target)
     result: dict[str, Lib] = {}
@@ -206,6 +254,10 @@ def reachable_siblings(
         if name == root.name or name in result:
             continue
         result[name] = libs[name]
+        # extras=() on purpose: deeper siblings are followed runtime-only. An
+        # installed dependency pulls its runtime deps, not its extras; following
+        # ``extras`` here would reintroduce the test-extra cycles the module
+        # docstring describes (e.g. engine[test] -> testing-utils[validation]).
         frontier |= _direct_in_tree_deps(libs[name], libs, extras=())
     return sorted(result.values(), key=lambda lib: lib.name)
 
@@ -221,10 +273,29 @@ def topological_order(
     """Return ``targets`` ordered dependencies-first.
 
     Edges follow runtime deps plus the given ``extras`` (the dependency set
-    actually installed during a release). Raises :class:`ValueError` on a cycle
-    rather than emitting an undefined order.
+    actually installed during a release).
+
+    Parameters
+    ----------
+    targets
+        Packages to order, as canonical dist names or libs/ dir names.
+    libs
+        The in-tree package index from :func:`load_libs`.
+    extras
+        Optional-dependency extras installed during the release.
+
+    Returns
+    -------
+    The ``targets`` (resolved to their :class:`Lib`) ordered so each package
+    appears after its in-tree dependencies.
+
+    Raises
+    ------
+    ValueError
+        If the dependency graph over ``targets`` contains a cycle.
     """
-    resolved = [_resolve_dir_name(libs, t) for t in targets]
+    by_dir = {lib.dir_name: lib for lib in libs.values()}
+    resolved = [_resolve_dir_name(libs, t, by_dir) for t in targets]
     subset = {lib.name for lib in resolved}
     edges = _edges(libs, extras)
 
@@ -266,6 +337,11 @@ def _cmd_topo(args: argparse.Namespace) -> int:
     return 0
 
 
+def _add_extra_arg(parser: argparse.ArgumentParser, help_text: str) -> None:
+    """Add the shared repeatable ``--extra`` option to a subparser."""
+    parser.add_argument("--extra", action="append", default=[], help=help_text)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m vivarium_build_utils.dependencies",
@@ -279,24 +355,14 @@ def main(argv: list[str] | None = None) -> int:
         "line as '<dir>\\t<pretend-version env var>\\t<pending version>'.",
     )
     siblings.add_argument("target", help="Target package (dist name or libs/ dir name).")
-    siblings.add_argument(
-        "--extra",
-        action="append",
-        default=[],
-        help="Optional-dependency extra the install activates (repeatable).",
-    )
+    _add_extra_arg(siblings, "Optional-dependency extra the install activates (repeatable).")
     siblings.set_defaults(func=_cmd_siblings)
 
     topo = subparsers.add_parser(
         "topo", help="Print the given packages ordered dependencies-first."
     )
     topo.add_argument("targets", nargs="+", help="Packages (dist names or dir names).")
-    topo.add_argument(
-        "--extra",
-        action="append",
-        default=[],
-        help="Optional-dependency extra installed during release (repeatable).",
-    )
+    _add_extra_arg(topo, "Optional-dependency extra installed during release (repeatable).")
     topo.set_defaults(func=_cmd_topo)
 
     args = parser.parse_args(argv)

--- a/src/vivarium_build_utils/dependencies.py
+++ b/src/vivarium_build_utils/dependencies.py
@@ -343,6 +343,17 @@ def _add_extra_arg(parser: argparse.ArgumentParser, help_text: str) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the CLI: dispatch the ``siblings`` or ``topo`` subcommand.
+
+    Parameters
+    ----------
+    argv
+        Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns
+    -------
+    The process exit code (0 on success).
+    """
     parser = argparse.ArgumentParser(
         prog="python -m vivarium_build_utils.dependencies",
         description="Intra-monorepo dependency graph queries.",

--- a/src/vivarium_build_utils/dependencies.py
+++ b/src/vivarium_build_utils/dependencies.py
@@ -1,0 +1,307 @@
+"""Intra-monorepo dependency graph utilities.
+
+A *monorepo* here is a repository whose packages live in ``<root>/libs/<pkg>/``,
+each with its own ``pyproject.toml`` declaring a ``[project].name`` (e.g.
+``vivarium-engine``). Two consumers use this module:
+
+* ``make install`` (``base.mk``) - to install a package's in-tree sibling
+  dependencies from source, so a single PR can update interdependent packages
+  without an intermediate release.
+* the vivarium-suite release workflow - to order releases dependencies-first.
+
+Outside that layout the helpers report "not a monorepo" (:func:`find_libs_root`
+returns ``None`` and :func:`load_libs` returns an empty mapping), so importing or
+invoking this module from a standalone repo is harmless - callers simply no-op.
+
+Two graphs matter. The *runtime* graph (edges from ``[project.dependencies]``)
+governs what an installed wheel pulls in and is expected to be acyclic. The
+*install-time* graph additionally follows the optional-dependency extras that a
+given install activates (and the ``pkg[extra]`` self-references within them);
+folding in every extra can introduce cycles (e.g. a test-only dependency that
+depends back on its consumer), so callers choose which extras to include.
+"""
+
+from __future__ import annotations
+
+import argparse
+import graphlib
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+_CANONICALIZE = re.compile(r"[-_.]+")
+# Distribution name (optionally with [extras]) at the start of a requirement string.
+_REQUIREMENT = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:\[([^\]]*)\])?")
+_VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+
+
+def canonical_name(name: str) -> str:
+    """Return the PEP 503 normalized form of a distribution name."""
+    return _CANONICALIZE.sub("-", name).strip("-").lower()
+
+
+def pretend_version_env_var(dist_name: str) -> str:
+    """Return the ``setuptools_scm`` pretend-version env var for a distribution.
+
+    ``setuptools_scm`` reads ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_<NAME>`` where
+    ``<NAME>`` is the distribution name normalized (PEP 503) then upper-cased with
+    hyphens replaced by underscores - e.g. ``vivarium-engine`` becomes
+    ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VIVARIUM_ENGINE``.
+    """
+    return (
+        "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_"
+        + canonical_name(dist_name).replace("-", "_").upper()
+    )
+
+
+def _parse_requirement(spec: str) -> tuple[str, list[str]]:
+    """Return the canonical base name and extras of a requirement string.
+
+    Strips environment markers, version specifiers, and whitespace. e.g.
+    ``"vivarium-engine[test]>=5.1.0 ; python_version>'3.10'"`` ->
+    ``("vivarium-engine", ["test"])``.
+    """
+    spec = spec.split(";", 1)[0]
+    match = _REQUIREMENT.match(spec)
+    if not match:
+        return "", []
+    extras = [e.strip() for e in (match.group(2) or "").split(",") if e.strip()]
+    return canonical_name(match.group(1)), extras
+
+
+@dataclass
+class Lib:
+    """A single in-tree package."""
+
+    name: str  # canonical distribution name, e.g. "vivarium-engine"
+    directory: Path  # the libs/<dir> path
+    runtime: list[tuple[str, list[str]]] = field(default_factory=list)
+    extras: dict[str, list[tuple[str, list[str]]]] = field(default_factory=dict)
+
+    @property
+    def dir_name(self) -> str:
+        return self.directory.name
+
+    def changelog_version(self) -> str | None:
+        """Return the pending version from the first CHANGELOG.rst line, if any."""
+        changelog = self.directory / "CHANGELOG.rst"
+        if not changelog.exists():
+            return None
+        for line in changelog.read_text(encoding="utf-8").splitlines():
+            match = _VERSION.search(line)
+            if match:
+                return match.group(0)
+        return None
+
+
+def find_libs_root(start: Path | str | None = None) -> Path | None:
+    """Return the monorepo ``libs/`` directory for ``start``, or None.
+
+    Walks upward from ``start`` (default: cwd). A directory qualifies as the libs
+    root when it is named ``libs`` and contains at least one ``*/pyproject.toml``.
+    Returns ``None`` when no such ancestor exists - i.e. this is not a monorepo
+    layout - so standalone repos are detected and left alone.
+    """
+    start_path = Path(start).resolve() if start else Path.cwd()
+    for directory in (start_path, *start_path.parents):
+        if directory.name == "libs" and any(directory.glob("*/pyproject.toml")):
+            return directory
+        candidate = directory / "libs"
+        if candidate.is_dir() and any(candidate.glob("*/pyproject.toml")):
+            return candidate
+    return None
+
+
+def load_libs(libs_root: Path | None = None) -> dict[str, Lib]:
+    """Load all in-tree packages, keyed by canonical distribution name.
+
+    Returns an empty mapping when not in a monorepo layout.
+    """
+    if libs_root is None:
+        libs_root = find_libs_root()
+    if libs_root is None:
+        return {}
+
+    libs: dict[str, Lib] = {}
+    for pyproject in sorted(libs_root.glob("*/pyproject.toml")):
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        project = data.get("project", {})
+        name = project.get("name")
+        if not name:
+            continue
+        runtime = [_parse_requirement(dep) for dep in project.get("dependencies", [])]
+        extras = {
+            extra: [_parse_requirement(dep) for dep in deps]
+            for extra, deps in project.get("optional-dependencies", {}).items()
+        }
+        canonical = canonical_name(name)
+        libs[canonical] = Lib(
+            name=canonical, directory=pyproject.parent, runtime=runtime, extras=extras
+        )
+    return libs
+
+
+def _resolve_dir_name(libs: dict[str, Lib], target: str) -> Lib:
+    """Resolve a target given either its canonical dist name or its libs/ dir name."""
+    canonical = canonical_name(target)
+    if canonical in libs:
+        return libs[canonical]
+    by_dir = {lib.dir_name: lib for lib in libs.values()}
+    if target in by_dir:
+        return by_dir[target]
+    raise KeyError(f"No in-tree package matching {target!r}")
+
+
+def _direct_in_tree_deps(lib: Lib, libs: dict[str, Lib], extras: tuple[str, ...]) -> set[str]:
+    """In-tree dist names directly required by ``lib`` under the given extras.
+
+    Expands the lib's own ``pkg[extra]`` self-references so that a meta-extra like
+    ``ci_github = ["vivarium-engine[test,docs,lint]"]`` contributes the deps of
+    ``test``/``docs``/``lint``. Self edges (the package depending on itself) are
+    not returned.
+    """
+    found: set[str] = set()
+    queue: list[tuple[str, list[str]]] = list(lib.runtime)
+    for extra in extras:
+        queue.extend(lib.extras.get(extra, []))
+    seen_self_extras: set[str] = set()
+    while queue:
+        base, dep_extras = queue.pop()
+        if not base:
+            continue
+        if base == lib.name:
+            # Self-reference such as pkg[test]: pull in those extras' deps.
+            for extra in dep_extras:
+                if extra not in seen_self_extras:
+                    seen_self_extras.add(extra)
+                    queue.extend(lib.extras.get(extra, []))
+            continue
+        if base in libs:
+            found.add(base)
+    return found
+
+
+def reachable_siblings(
+    target: str, libs: dict[str, Lib], extras: tuple[str, ...] = ()
+) -> list[Lib]:
+    """Return the transitive in-tree siblings ``target`` depends on.
+
+    The target's own ``extras`` are followed (matching what the install will
+    activate); deeper siblings contribute only their runtime dependencies, since
+    that is all an installed dependency pulls in. The target itself is excluded.
+    Order is unspecified - callers install siblings with ``--no-deps``, so the
+    set is what matters and the result is immune to dependency cycles.
+    """
+    root = _resolve_dir_name(libs, target)
+    result: dict[str, Lib] = {}
+    frontier = _direct_in_tree_deps(root, libs, extras)
+    while frontier:
+        name = frontier.pop()
+        if name == root.name or name in result:
+            continue
+        result[name] = libs[name]
+        frontier |= _direct_in_tree_deps(libs[name], libs, extras=())
+    return sorted(result.values(), key=lambda lib: lib.name)
+
+
+def _edges(libs: dict[str, Lib], extras: tuple[str, ...]) -> dict[str, set[str]]:
+    """Build the dependency edge map (lib -> in-tree deps) over the given extras."""
+    return {name: _direct_in_tree_deps(lib, libs, extras) for name, lib in libs.items()}
+
+
+def topological_order(
+    targets: list[str], libs: dict[str, Lib], extras: tuple[str, ...] = ()
+) -> list[Lib]:
+    """Return ``targets`` ordered dependencies-first.
+
+    Edges follow runtime deps plus the given ``extras`` (the dependency set
+    actually installed during a release). Raises :class:`ValueError` on a cycle
+    rather than emitting an undefined order.
+    """
+    resolved = [_resolve_dir_name(libs, t) for t in targets]
+    subset = {lib.name for lib in resolved}
+    edges = _edges(libs, extras)
+
+    # Add nodes and their in-subset dependencies sorted, so the ordering among
+    # otherwise-independent packages is deterministic.
+    sorter: graphlib.TopologicalSorter[str] = graphlib.TopologicalSorter()
+    for name in sorted(subset):
+        sorter.add(name, *sorted(dep for dep in edges.get(name, set()) if dep in subset))
+    try:
+        order = list(sorter.static_order())
+    except graphlib.CycleError as exc:
+        raise ValueError(
+            f"Dependency cycle detected among in-tree packages: {exc.args[1]}"
+        ) from exc
+    return [libs[name] for name in order]
+
+
+def _cmd_siblings(args: argparse.Namespace) -> int:
+    libs = load_libs()
+    if not libs:
+        return 0  # not a monorepo: nothing to pre-install
+    extras = tuple(args.extra)
+    for sibling in reachable_siblings(args.target, libs, extras):
+        version = sibling.changelog_version() or ""
+        # Tab-separated: <directory> <pretend-version env var> <pending version>
+        print(f"{sibling.directory}\t{pretend_version_env_var(sibling.name)}\t{version}")
+    return 0
+
+
+def _cmd_topo(args: argparse.Namespace) -> int:
+    libs = load_libs()
+    if not libs:
+        for target in args.targets:
+            print(target)
+        return 0
+    extras = tuple(args.extra)
+    for lib in topological_order(args.targets, libs, extras):
+        print(lib.dir_name)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m vivarium_build_utils.dependencies",
+        description="Intra-monorepo dependency graph queries.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    siblings = subparsers.add_parser(
+        "siblings",
+        help="Print the transitive in-tree siblings a package depends on, one per "
+        "line as '<dir>\\t<pretend-version env var>\\t<pending version>'.",
+    )
+    siblings.add_argument("target", help="Target package (dist name or libs/ dir name).")
+    siblings.add_argument(
+        "--extra",
+        action="append",
+        default=[],
+        help="Optional-dependency extra the install activates (repeatable).",
+    )
+    siblings.set_defaults(func=_cmd_siblings)
+
+    topo = subparsers.add_parser(
+        "topo", help="Print the given packages ordered dependencies-first."
+    )
+    topo.add_argument("targets", nargs="+", help="Packages (dist names or dir names).")
+    topo.add_argument(
+        "--extra",
+        action="append",
+        default=[],
+        help="Optional-dependency extra installed during release (repeatable).",
+    )
+    topo.set_defaults(func=_cmd_topo)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,214 @@
+"""Tests for the intra-monorepo dependency graph utility."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from vivarium_build_utils import dependencies
+
+
+def _write_lib(
+    libs_root: Path,
+    dir_name: str,
+    dist_name: str,
+    dependencies: list[str] | None = None,
+    optional: dict[str, list[str]] | None = None,
+    changelog_version: str | None = None,
+) -> None:
+    pkg = libs_root / dir_name
+    pkg.mkdir(parents=True)
+    deps = "".join(f'    "{d}",\n' for d in (dependencies or []))
+    extras = ""
+    for name, items in (optional or {}).items():
+        joined = "".join(f'    "{i}",\n' for i in items)
+        extras += f"{name} = [\n{joined}]\n"
+    pkg.joinpath("pyproject.toml").write_text(
+        textwrap.dedent(f"""\
+            [project]
+            name = "{dist_name}"
+            dependencies = [
+            {deps}]
+            [project.optional-dependencies]
+            {extras}
+            """),
+        encoding="utf-8",
+    )
+    if changelog_version is not None:
+        pkg.joinpath("CHANGELOG.rst").write_text(
+            f"**{changelog_version} - 01/01/26**\n", encoding="utf-8"
+        )
+
+
+@pytest.fixture()
+def suite(tmp_path: Path) -> Path:
+    """A monorepo mirroring the real vivarium-suite graph, incl. a cycle case."""
+    libs = tmp_path / "libs"
+    libs.mkdir()
+    _write_lib(libs, "artifact", "vivarium-artifact", changelog_version="2.0.0")
+    _write_lib(libs, "config-tree", "vivarium-config-tree", changelog_version="5.0.1")
+    _write_lib(
+        libs,
+        "engine",
+        "vivarium-engine",
+        dependencies=["vivarium-artifact", "vivarium-config-tree", "pandas"],
+        optional={
+            "test": ["vivarium-testing-utils", "pytest"],
+            "docs": ["sphinx"],
+            "lint": ["black"],
+            "ci_github": ["vivarium-engine[test,docs,lint]"],
+        },
+        changelog_version="6.1.0",
+    )
+    _write_lib(
+        libs,
+        "cluster-tools",
+        "vivarium-cluster-tools",
+        dependencies=["vivarium-engine>=5.1.0", "vivarium-config-tree>=5.0.0"],
+        optional={
+            "test": ["vivarium-testing-utils"],
+            "ci_github": ["vivarium-cluster-tools[test]"],
+        },
+        changelog_version="2.2.0",
+    )
+    # testing-utils: no in-tree *runtime* deps, but its validation extra depends
+    # back on engine -> would create a cycle if all extras were folded in.
+    _write_lib(
+        libs,
+        "testing-utils",
+        "vivarium-testing-utils",
+        dependencies=["pyyaml"],
+        optional={
+            "validation": ["vivarium-engine", "vivarium-gbd-mapping"],
+            "test": ["pytest"],
+            "ci_github": ["vivarium-testing-utils[test]"],
+        },
+        changelog_version="0.4.0",
+    )
+    _write_lib(libs, "gbd-mapping", "vivarium-gbd-mapping", changelog_version="6.0.0")
+    return libs
+
+
+def test_canonical_name() -> None:
+    assert dependencies.canonical_name("Vivarium_Engine") == "vivarium-engine"
+    assert dependencies.canonical_name("vivarium..config__tree") == "vivarium-config-tree"
+
+
+def test_pretend_version_env_var() -> None:
+    assert (
+        dependencies.pretend_version_env_var("vivarium-engine")
+        == "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VIVARIUM_ENGINE"
+    )
+
+
+@pytest.mark.parametrize(
+    "spec, expected",
+    [
+        ("vivarium-engine>=5.1.0", ("vivarium-engine", [])),
+        ("vivarium-engine[test,docs]>=5.1.0", ("vivarium-engine", ["test", "docs"])),
+        ("pkg ; python_version < '3.11'", ("pkg", [])),
+        ("vivarium_testing_utils", ("vivarium-testing-utils", [])),
+    ],
+)
+def test_parse_requirement(spec: str, expected: tuple[str, list[str]]) -> None:
+    assert dependencies._parse_requirement(spec) == expected
+
+
+def test_find_libs_root_from_package_dir(suite: Path) -> None:
+    assert dependencies.find_libs_root(suite / "engine") == suite
+
+
+def test_find_libs_root_from_repo_root(suite: Path) -> None:
+    assert dependencies.find_libs_root(suite.parent) == suite
+
+
+def test_find_libs_root_not_a_monorepo(tmp_path: Path) -> None:
+    standalone = tmp_path / "standalone"
+    standalone.mkdir()
+    standalone.joinpath("pyproject.toml").write_text('[project]\nname = "foo"\n')
+    assert dependencies.find_libs_root(standalone) is None
+
+
+def test_load_libs_empty_outside_monorepo(tmp_path: Path) -> None:
+    assert dependencies.load_libs(tmp_path) == {}
+
+
+def test_reachable_siblings_runtime(suite: Path) -> None:
+    libs = dependencies.load_libs(suite)
+    names = {lib.name for lib in dependencies.reachable_siblings("engine", libs)}
+    assert names == {"vivarium-artifact", "vivarium-config-tree"}
+
+
+def test_reachable_siblings_transitive(suite: Path) -> None:
+    libs = dependencies.load_libs(suite)
+    names = {lib.name for lib in dependencies.reachable_siblings("cluster-tools", libs)}
+    # cluster-tools -> engine -> {artifact, config-tree}
+    assert names == {"vivarium-engine", "vivarium-artifact", "vivarium-config-tree"}
+
+
+def test_reachable_siblings_follows_ci_extra(suite: Path) -> None:
+    libs = dependencies.load_libs(suite)
+    names = {
+        lib.name for lib in dependencies.reachable_siblings("engine", libs, extras=("ci_github",))
+    }
+    # ci_github -> test -> testing-utils, in addition to runtime deps.
+    assert "vivarium-testing-utils" in names
+    assert {"vivarium-artifact", "vivarium-config-tree"} <= names
+
+
+def test_reachable_siblings_accepts_dist_name(suite: Path) -> None:
+    libs = dependencies.load_libs(suite)
+    by_dir = dependencies.reachable_siblings("engine", libs)
+    by_name = dependencies.reachable_siblings("vivarium-engine", libs)
+    assert {lib.name for lib in by_dir} == {lib.name for lib in by_name}
+
+
+def test_changelog_version(suite: Path) -> None:
+    libs = dependencies.load_libs(suite)
+    assert libs["vivarium-engine"].changelog_version() == "6.1.0"
+
+
+def test_topological_order_runtime(suite: Path) -> None:
+    libs = dependencies.load_libs(suite)
+    order = [
+        lib.dir_name
+        for lib in dependencies.topological_order(
+            ["cluster-tools", "engine", "config-tree", "artifact"], libs
+        )
+    ]
+    assert order.index("artifact") < order.index("engine")
+    assert order.index("config-tree") < order.index("engine")
+    assert order.index("engine") < order.index("cluster-tools")
+
+
+def test_topological_order_runtime_is_acyclic_with_testing_utils(suite: Path) -> None:
+    """Runtime-only graph has no cycle even though testing-utils[validation] would."""
+    libs = dependencies.load_libs(suite)
+    order = dependencies.topological_order(["engine", "testing-utils", "gbd-mapping"], libs)
+    assert {lib.dir_name for lib in order} == {"engine", "testing-utils", "gbd-mapping"}
+
+
+def test_topological_order_ci_github_is_acyclic(suite: Path) -> None:
+    """ci_github edges keep testing-utils orderable before its consumers."""
+    libs = dependencies.load_libs(suite)
+    order = [
+        lib.dir_name
+        for lib in dependencies.topological_order(
+            ["engine", "testing-utils"], libs, extras=("ci_github",)
+        )
+    ]
+    # engine[ci_github] -> test -> testing-utils, so testing-utils releases first.
+    assert order.index("testing-utils") < order.index("engine")
+
+
+def test_topological_order_detects_cycle(suite: Path) -> None:
+    """Folding validation into the graph creates engine <-> testing-utils."""
+    libs = dependencies.load_libs(suite)
+    # Make testing-utils' ci_github pull validation (the regression we guard against).
+    libs["vivarium-testing-utils"].extras["ci_github"] = [
+        ("vivarium-testing-utils", ["validation"])
+    ]
+    with pytest.raises(ValueError, match="cycle"):
+        dependencies.topological_order(["engine", "testing-utils"], libs, extras=("ci_github",))

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -151,7 +151,8 @@ def test_reachable_siblings_transitive(suite: Path) -> None:
 def test_reachable_siblings_follows_ci_extra(suite: Path) -> None:
     libs = dependencies.load_libs(suite)
     names = {
-        lib.name for lib in dependencies.reachable_siblings("engine", libs, extras=("ci_github",))
+        lib.name
+        for lib in dependencies.reachable_siblings("engine", libs, extras=("ci_github",))
     }
     # ci_github -> test -> testing-utils, in addition to runtime deps.
     assert "vivarium-testing-utils" in names
@@ -211,4 +212,135 @@ def test_topological_order_detects_cycle(suite: Path) -> None:
         ("vivarium-testing-utils", ["validation"])
     ]
     with pytest.raises(ValueError, match="cycle"):
-        dependencies.topological_order(["engine", "testing-utils"], libs, extras=("ci_github",))
+        dependencies.topological_order(
+            ["engine", "testing-utils"], libs, extras=("ci_github",)
+        )
+
+
+def test_topological_order_independent_nodes_are_alphabetical(suite: Path) -> None:
+    """Mutually-independent packages come out in a stable alphabetical order."""
+    libs = dependencies.load_libs(suite)
+    order = [
+        lib.dir_name
+        for lib in dependencies.topological_order(
+            ["gbd-mapping", "config-tree", "artifact"], libs
+        )
+    ]
+    assert order == ["artifact", "config-tree", "gbd-mapping"]
+
+
+def test_resolve_dir_name_unknown_target_raises(suite: Path) -> None:
+    libs = dependencies.load_libs(suite)
+    with pytest.raises(KeyError, match="no-such-pkg"):
+        dependencies._resolve_dir_name(libs, "no-such-pkg")
+
+
+def test_load_libs_skips_pyproject_without_project_name(suite: Path) -> None:
+    # A pyproject.toml lacking [project].name must be ignored, not crash.
+    (suite / "not-a-package").mkdir()
+    (suite / "not-a-package" / "pyproject.toml").write_text(
+        "[build-system]\nrequires = []\n", encoding="utf-8"
+    )
+    libs = dependencies.load_libs(suite)
+    assert "not-a-package" not in {lib.dir_name for lib in libs.values()}
+
+
+@pytest.mark.parametrize("spec", ["", ">=1.0", "  ", "[extras]"])
+def test_parse_requirement_unparseable_returns_empty(spec: str) -> None:
+    assert dependencies._parse_requirement(spec) == ("", [])
+
+
+def test_pretend_version_env_var_normalizes() -> None:
+    # Underscores, dots, and mixed case all normalize before upper-casing.
+    assert (
+        dependencies.pretend_version_env_var("Vivarium_Config.Tree")
+        == "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VIVARIUM_CONFIG_TREE"
+    )
+
+
+def test_find_libs_root_defaults_to_cwd(suite: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The production path passes no argument and relies on cwd.
+    monkeypatch.chdir(suite / "engine")
+    assert dependencies.find_libs_root() == suite
+
+
+def test_changelog_version_missing_file_returns_none(suite: Path) -> None:
+    # gbd-mapping is created with a CHANGELOG; remove it to exercise the None branch.
+    (suite / "gbd-mapping" / "CHANGELOG.rst").unlink()
+    libs = dependencies.load_libs(suite)
+    assert libs["vivarium-gbd-mapping"].changelog_version() is None
+
+
+def test_changelog_version_no_version_line_returns_none(suite: Path) -> None:
+    (suite / "gbd-mapping" / "CHANGELOG.rst").write_text(
+        "Changelog\n=========\nUnreleased changes.\n", encoding="utf-8"
+    )
+    libs = dependencies.load_libs(suite)
+    assert libs["vivarium-gbd-mapping"].changelog_version() is None
+
+
+# --- CLI layer (the contract base.mk parses) -------------------------------------
+
+
+def test_cmd_siblings_output_format(
+    suite: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin the exact tab-separated `<dir>\\t<env var>\\t<version>` line base.mk reads."""
+    monkeypatch.chdir(suite / "engine")
+    assert dependencies.main(["siblings", "engine"]) == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert {Path(line.split("\t")[0]).name for line in lines} == {"artifact", "config-tree"}
+    for line in lines:
+        directory, env_var, version = line.split("\t")  # exactly three columns
+        assert Path(directory).is_absolute()
+        assert env_var.startswith("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_")
+        assert version  # these fixtures all set a CHANGELOG version
+
+
+def test_cmd_siblings_follows_extra(
+    suite: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(suite / "engine")
+    assert dependencies.main(["siblings", "engine", "--extra", "ci_github"]) == 0
+    dirs = {Path(line.split("\t")[0]).name for line in capsys.readouterr().out.splitlines()}
+    assert "testing-utils" in dirs  # ci_github -> test -> testing-utils
+
+
+def test_cmd_siblings_empty_version_column(
+    suite: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sibling with no CHANGELOG version emits an empty third column, not a missing one."""
+    (suite / "config-tree" / "CHANGELOG.rst").unlink()
+    monkeypatch.chdir(suite / "engine")
+    assert dependencies.main(["siblings", "engine"]) == 0
+    rows = {
+        Path(line.split("\t", 2)[0]).name: line.split("\t", 2)
+        for line in capsys.readouterr().out.splitlines()
+    }
+    assert rows["config-tree"][2] == ""  # third column present and empty
+
+
+def test_cmd_topo_prints_dir_names_deps_first(
+    suite: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(suite)
+    assert dependencies.main(["topo", "cluster-tools", "engine", "artifact"]) == 0
+    order = capsys.readouterr().out.split()
+    assert order.index("artifact") < order.index("engine") < order.index("cluster-tools")
+
+
+def test_cli_no_op_outside_monorepo(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    standalone = tmp_path / "standalone"
+    standalone.mkdir()
+    standalone.joinpath("pyproject.toml").write_text(
+        '[project]\nname = "foo"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(standalone)
+    # siblings: prints nothing, succeeds.
+    assert dependencies.main(["siblings", "foo"]) == 0
+    assert capsys.readouterr().out == ""
+    # topo: echoes the targets back verbatim (the passthrough base.mk relies on).
+    assert dependencies.main(["topo", "foo", "bar"]) == 0
+    assert capsys.readouterr().out.split() == ["foo", "bar"]


### PR DESCRIPTION
## Install in-tree sibling dependencies at pending versions

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7187
### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Currently, if some changes to libs in the monorepo require an upstream
lib to be released, we need to first PR and release the upstream one
so the new version is available for use via pypi. This PR (and the
corresponding one in vivairum-suite), fixes that by creating the
dependency DAG and actually installing editably for those that
changed.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

various tests are added. Note that currently vbu does not actually
even have a Jenkinsfile so it's not even getting built. I have created
a ticket to promote vbu to a first-class repo w/ proper CI.
