### PR TITLE
Albrja/feature/mic 6103/ping cron branches

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@
    - Search recursively for ``py.typed`` markers so monorepo packages are detected
    - ``make install``: install in editable_mode=compat to not break py.typed marker discovery
    - Add GitHUb App authenticaion support for deployable packages
+   - Bugfix: Correctly handle capturing cron branch name to send Slack notification for schedule builds
 
 **3.2.2 - 05/07/26**
 

--- a/vars/reusable_pipeline.groovy
+++ b/vars/reusable_pipeline.groovy
@@ -319,7 +319,7 @@ def call(Map config = [:]){
           if (params.SLACK_TO) {
             channelName = params.SLACK_TO
             slackID = "channel"
-          } else if (env.BRANCH == "main" || scheduled_branches.contains(env.BRANCH)) {
+          } else if (env.BRANCH == "main" || scheduled_branches.contains(env.BRANCH_NAME)) {
             channelName = "simsci-ci-status"
             slackID = "channel"
           } else {


### PR DESCRIPTION
## Albrja/feature/mic 6103/ping cron branches

### Fix branch lookup for slack notifications on cron branches
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6103

### Changes and notes
-fixes bug in git branch lookup to send slack notification when cron branches fail overnight builds

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

