### PR TITLE
Sbachmei/hotfix/update get vbu versions script for monorepo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.3.1 - 06/17/26**
+
+- Bugfix: Handle monorepo directory layout in get_vbu_version.py
+
 **3.3.0 - 06/17/26**
 
 - Add monorepo support: top-level ``monorepo()`` step that provisions per-package

--- a/bootstrap/resources/scripts/get_vbu_version.py
+++ b/bootstrap/resources/scripts/get_vbu_version.py
@@ -23,6 +23,23 @@ MINICONDA_DIR = "/svc-simsci/vbu_bootstrap_envs/miniconda3"
 IHME_PYPI = "https://artifactory.ihme.washington.edu/artifactory/api/pypi/pypi-shared/"
 
 
+def _get_package_subdir() -> str:
+    """Return ``libs/<pkg>`` for monorepo per-package builds, else empty string.
+
+    Derived from Jenkins' ``JOB_NAME`` ("<prefix>/<repo>/libs/<pkg>/<branch>").
+    Standalone repos have no ``libs`` segment, so subdir stays empty and the
+    script operates on the workspace root (the pre-monorepo behavior).
+    """
+    parts = os.environ.get("JOB_NAME", "").split("/")
+    try:
+        i = parts.index("libs")
+    except ValueError:
+        return ""
+    if i + 1 >= len(parts):
+        return ""
+    return f"{parts[i]}/{parts[i + 1]}"
+
+
 def _get_max_python_version() -> str:
     """Read python_versions.json and return the maximum supported Python version."""
     # Ensure we're in a directory with python_versions.json
@@ -115,6 +132,9 @@ def _extract_vbu_version(dry_run_output: str) -> str:
 def main() -> str:
     """Main function to orchestrate version resolution."""
 
+    subdir = _get_package_subdir()
+    if subdir:
+        os.chdir(subdir)
     python_version = _get_max_python_version()
     dry_run_output = _run_pip_dry_run(python_version)
     vbu_version = _extract_vbu_version(dry_run_output)


### PR DESCRIPTION
## Update get vbu versions script for monorepo

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> hotfix
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

The original version of get_vbu_version() was assuming that the 
python_versions.json lived in the repo root dir. This is obviously 
different in vivarium-suite since each lib gets its own json.
Because we were hard-coding the version returned by the
bootstrapping during migration, this just never got tested.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

I tested that this will work by pushing a test branch in
Artifact that hard-coded this branch.

https://jenkins.simsci.ihme.washington.edu/job/Public/job/vivarium-suite/job/libs/job/artifact/job/sbachmei%252Ftest-get-vbu-version/
