### PR TITLE
Always resolve vivarium-built-utils version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.3.2 - 06/17/26**
+
+- Bugfix: Resolve vivarium-built-utils version even if the package doesn't declare it as a dependency
+
 **3.3.1 - 06/17/26**
 
 - Bugfix: Handle monorepo directory layout in get_vbu_version.py

--- a/bootstrap/resources/scripts/get_vbu_version.py
+++ b/bootstrap/resources/scripts/get_vbu_version.py
@@ -79,10 +79,14 @@ def _run_pip_dry_run(python_version: str) -> str:
     # NOTE: if updating supported python versions, be sure to create a new
     # conda environment with the appropriate python version and uv installed
     # at MINICONDA_DIR/envs/py{env_version}
+    #
+    # NOTE: We pass `vivarium-build-utils` alongside `.` so the dry-run always resolves
+    # vbu, even when the lib's pyproject doesn't declare it. For libs that do declare
+    # vbu, the bare requirement adds no constraint and the existing pin drives resolution.
     cmd = f"""
     source {MINICONDA_DIR}/etc/profile.d/conda.sh
     conda activate py{env_version}
-    uv pip install --dry-run . --extra-index-url {IHME_PYPI}simple/ --index-strategy unsafe-best-match --no-cache
+    uv pip install --dry-run . vivarium-build-utils --extra-index-url {IHME_PYPI}simple/ --index-strategy unsafe-best-match --no-cache
     """
 
     try:


### PR DESCRIPTION
## Always resolve vivarium-built-utils version
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

This allows even libs that don't declare vbu as a dependency (`compat` being
the motivator here) to use vbu / Jenkinsfile

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

